### PR TITLE
Fix spurious end-name mismatch under --check (#52)

### DIFF
--- a/share/aquarius/grammar/ada/aqua/ada-checks-matching_name.aqua
+++ b/share/aquarius/grammar/ada/aqua/ada-checks-matching_name.aqua
@@ -22,12 +22,14 @@ feature
          Match : String
       do
          Match := Identifiers.Interpolate (".")
-         if Match /= Original_Name then
-            if Match.To_Lower = Original_Name.To_Lower then
-               Error ("Case of " & Match & " does not match " & Original_Name)
-            else
-               Error (Match & " does not match " & Original_Name)
-            end
+         --  Ada is case-insensitive, and the two sides come from differently
+         --  normalised text sources, so compare case-insensitively. Skip when
+         --  the expected name is unknown: a mismatch cannot be asserted
+         --  against an empty name.
+         if Original_Name /= ""
+           and then Match.To_Lower /= Original_Name.To_Lower
+         then
+            Error (Match & " does not match " & Original_Name)
          end
       end
 end

--- a/share/aquarius/grammar/ada/aqua/ada-checks-package_specification.aqua
+++ b/share/aquarius/grammar/ada/aqua/ada-checks-package_specification.aqua
@@ -9,18 +9,25 @@ inherit
 feature
 
    Library_Spec : Ada.Library.Package_Specification
-   
+
+   Defining_Name : String
+
    After_Defining_Program_Unit_Name (Child : Ada.Checks.Defining_Program_Unit_Name)
       do
          Copy (Library_Spec)
-         
+
+         --  Full_Name is populated by the Ada.Library pass, which does not
+         --  run under --check; take the defining name directly from the
+         --  parsed identifiers so the end-name check has something to match.
+         Defining_Name := Child.Identifiers.Interpolate (".")
+
          across Child.Reference as Ref loop
             Ref.Tree.Cross_Reference (Entity, Ref.Entity, "reference")
          end
       end
-      
+
    Before_Matching_Name (Child : Ada.Checks.Matching_Name)
       do
-         Child.Set_Original_Name (Full_Name)
+         Child.Set_Original_Name (Defining_Name)
       end
 end


### PR DESCRIPTION
## Summary

Makes `--check` report a clean file cleanly, completing #52.

Under `--check` only the `checks` semantic pass runs; the `Ada.Library` pass that populates `Full_Name` does not. The package end-name check was therefore comparing the end designator against an empty `Full_Name` and reporting a mismatch on **every** unit, so `--check` could never report a clean file (always non-zero exit).

- **`ada-checks-package_specification.aqua`** — derive the expected name directly from the parsed defining identifiers instead of the (unpopulated) `Full_Name`.
- **`ada-checks-matching_name.aqua`** — compare case-insensitively (Ada identifiers are case-insensitive, and the two sides come from differently normalised text sources) and skip when the expected name is unknown. Removes the bogus "Case of X does not match" that fired on all units.

A genuine end-name mismatch is still reported; a case-only difference is not.

The companion `CONSTRAINT_ERROR` crash fix (string options in `Aquarius.Options`) is already on `main` (b18df3f), so this PR is just the semantic-check change.

## Verified exit codes

| input | exit |
|-------|------|
| clean package / procedure | 0 |
| valid `.ebnf` grammar | 0 |
| case-only end-name difference | 0 |
| syntax error | 1 |
| end-name mismatch | 1 |
| no grammar for extension | 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
