### PR TITLE
issue #50

### DIFF
--- a/.aquarius/grammar/normandy/normandy.ebnf
+++ b/.aquarius/grammar/normandy/normandy.ebnf
@@ -1,18 +1,18 @@
 top ::= package
 
-identifier ::= standard ada_identifier
-number     ::= standard ada_numeric_literal
-string     ::= standard backslash_escaped_string
-delimiter  ::= delimiters "(),;[]."
+identifier ::= .standard ada_identifier
+number     ::= .standard ada_numeric_literal
+string     ::= .standard backslash_escaped_string
+delimiter  ::= .delimiters "(),;[]."
 
 line_comment = "--"
 
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format ';' no_space_before new_line_after
-format ':' space_before space_after
-format ',' no_space_before space_after
-format '.' no_space_before no_space_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format ';' no_space_before new_line_after
+.format ':' space_before space_after
+.format ',' no_space_before space_after
+.format '.' no_space_before no_space_after
 
 package ::= 'package' package_name [ description ] declarations 'end'
 

--- a/aquarius_plugins/src/aquarius-plugins-ebnf-analyse.adb
+++ b/aquarius_plugins/src/aquarius-plugins-ebnf-analyse.adb
@@ -41,52 +41,6 @@ package body Aquarius.Plugins.EBNF.Analyse is
      (Raw_String : String)
       return String;
 
-   --------------------------------------
-   -- After_Cross_Reference_Definition --
-   --------------------------------------
-
-   procedure After_Cross_Reference_Definition
-     (Target : not null access Aquarius.Actions.Actionable'Class)
-   is
-      Tree           : constant Program_Tree := Program_Tree (Target);
-      Grammar        : constant Aquarius.Grammars.Aquarius_Grammar :=
-                         Aquarius.Grammars.Get_Grammar (Tree.all);
-      Reference_Node : constant Program_Tree :=
-                         Tree.Program_Child ("identifier");
-      Rule              : constant Aquarius.Syntax.Syntax_Tree :=
-                            Grammar.Reference_Name
-                              (Reference_Node, Reference_Node.Text);
-      Child_Item     : constant Program_Tree :=
-                         Tree.Program_Child ("terminal-or-rule");
-      Terminal      : constant Program_Tree :=
-        Child_Item.Program_Child ("terminal");
-      Non_Terminal  : constant Program_Tree :=
-        Child_Item.Program_Child ("identifier");
-   begin
-
-      if Terminal /= null then
-         declare
-            Terminal_Name : constant String := Terminal.Text;
-            Token         : constant String :=
-              Terminal_Name (Terminal_Name'First + 1 ..
-                               Terminal_Name'Last - 1);
-            Name_Child    : constant Aquarius.Syntax.Syntax_Tree :=
-                              Grammar.Reference_Terminal (Terminal, Token);
-         begin
-            Rule.Set_Cross_Reference (Name_Child);
-         end;
-      else
-         declare
-            Non_Terminal_Name : constant String := Non_Terminal.Text;
-            Name_Child        : constant Aquarius.Syntax.Syntax_Tree :=
-              Grammar.Reference_Name (Non_Terminal, Non_Terminal_Name);
-         begin
-            Rule.Set_Cross_Reference (Name_Child);
-         end;
-      end if;
-
-   end After_Cross_Reference_Definition;
-
    -----------------------------
    -- After_Format_Definition --
    -----------------------------
@@ -554,35 +508,6 @@ package body Aquarius.Plugins.EBNF.Analyse is
          Grammar.Add_Value (Child, Name, Value_Text);
       end if;
    end After_Value_Definition;
-
-   ----------------
-   -- After_When --
-   ----------------
-
-   procedure After_When
-     (Target : not null access Aquarius.Actions.Actionable'Class)
-   is
-      Tree  : constant Program_Tree := Program_Tree (Target);
-      Rule  : constant Program_Tree := Program_Tree (Tree.Left_Sibling);
-      Rule_Syntax   : constant Aquarius.Syntax.Syntax_Tree :=
-        Get_Syntax (Rule);
-      Preconditions : constant Program_Tree :=
-        Tree.Program_Child ("sequence_of_identifiers");
-
-   begin
-      if Preconditions /= null then
-         declare
-            Properties    : constant Array_Of_Program_Trees :=
-              Preconditions.Direct_Children ("identifier");
-         begin
-            for I in Properties'Range loop
-               Rule_Syntax.Add_Precondition_Property
-                 (Properties (I).First_Leaf.Text);
-            end loop;
-         end;
-      end if;
-
-   end After_When;
 
    ------------------------------
    -- Before_Format_Definition --

--- a/aquarius_plugins/src/aquarius-plugins-ebnf-analyse.ads
+++ b/aquarius_plugins/src/aquarius-plugins-ebnf-analyse.ads
@@ -14,13 +14,9 @@ package Aquarius.Plugins.EBNF.Analyse is
      (Target : not null access Aquarius.Actions.Actionable'Class);
    procedure After_Format_Definition
      (Target : not null access Aquarius.Actions.Actionable'Class);
-   procedure After_Cross_Reference_Definition
-     (Target : not null access Aquarius.Actions.Actionable'Class);
    procedure After_Syntax_Body
      (Target : not null access Aquarius.Actions.Actionable'Class);
    procedure After_Sequence_Of_Rules
-     (Target : not null access Aquarius.Actions.Actionable'Class);
-   procedure After_When
      (Target : not null access Aquarius.Actions.Actionable'Class);
    procedure After_Rule
      (Target : not null access Aquarius.Actions.Actionable'Class);

--- a/aquarius_plugins/src/aquarius-plugins-ebnf.adb
+++ b/aquarius_plugins/src/aquarius-plugins-ebnf.adb
@@ -80,20 +80,12 @@ package body Aquarius.Plugins.EBNF is
          Analyse.After_Format_Definition'Access);
 
       This.Register_Action
-        ("xref-definition", Analysis, After,
-         Analyse.After_Cross_Reference_Definition'Access);
-
-      This.Register_Action
         ("syntax-body", Analysis, After,
          Analyse.After_Syntax_Body'Access);
 
       This.Register_Action
         ("sequence-of-rules", Analysis, After,
          Analyse.After_Sequence_Of_Rules'Access);
-
-      This.Register_Action
-        ("optional_when", Analysis, After,
-         Analyse.After_When'Access);
 
       This.Register_Action
         ("rule", Analysis, After,

--- a/aquarius_programs/src/aquarius-grammars-ebnf.adb
+++ b/aquarius_programs/src/aquarius-grammars-ebnf.adb
@@ -50,7 +50,6 @@ package body Aquarius.Grammars.EBNF is
          New_Choice (Grammar.Frame, Internal),
          [Grammar.Reference_Name (Internal, "value-definition"),
           Grammar.Reference_Name (Internal, "format-definition"),
-          Grammar.Reference_Name (Internal, "xref-definition"),
           Grammar.Reference_Name (Internal, "rule-definition")]);
       Add_Non_Terminal
         (Grammar, "value-definition",
@@ -61,16 +60,10 @@ package body Aquarius.Grammars.EBNF is
       Add_Non_Terminal
         (Grammar, "format-definition",
          New_Sequence (Grammar.Frame, Internal),
-         [Grammar.Reference_Terminal (Internal, "format"),
+         [Grammar.Reference_Terminal (Internal, ".format"),
           Grammar.Reference_Name (Internal, "terminal-or-rule"),
           Grammar.Reference_Name (Internal, "list-of-formats",
                           Indent_Rule => True)]);
-      Add_Non_Terminal
-        (Grammar, "xref-definition",
-         New_Sequence (Grammar.Frame, Internal),
-         [Grammar.Reference_Terminal (Internal, "xref"),
-          Grammar.Reference_Name (Internal, "identifier"),
-          Grammar.Reference_Name (Internal, "terminal-or-rule")]);
 
       Add_Non_Terminal (Grammar, "terminal-or-rule",
                         New_Choice (Grammar.Frame, Internal),
@@ -103,7 +96,7 @@ package body Aquarius.Grammars.EBNF is
 
       Add_Non_Terminal (Grammar, "standard-body",
                         New_Sequence (Grammar.Frame, Internal),
-                        [Grammar.Reference_Terminal (Internal, "standard"),
+                        [Grammar.Reference_Terminal (Internal, ".standard"),
                          Grammar.Reference_Name (Internal, "identifier")]);
 
       Add_Non_Terminal (Grammar, "regular-expression-body",
@@ -112,7 +105,7 @@ package body Aquarius.Grammars.EBNF is
 
       Add_Non_Terminal (Grammar, "delimiter-body",
                         New_Sequence (Grammar.Frame, Internal),
-                        [Grammar.Reference_Terminal (Internal, "delimiters"),
+                        [Grammar.Reference_Terminal (Internal, ".delimiters"),
                          Grammar.Reference_Name (Internal, "string")]);
 
       Add_Non_Terminal
@@ -124,18 +117,7 @@ package body Aquarius.Grammars.EBNF is
 
       Add_Non_Terminal (Grammar, "sequence-of-rules",
                         New_Repeat (Grammar.Frame, Internal, False, null),
-                        [Grammar.Reference_Name (Internal, "rule"),
-                         Grammar.Reference_Name (Internal, "optional_when")]);
-
-      Add_Non_Terminal (Grammar, "optional_when",
-                        New_Optional (Grammar.Frame, Internal),
-                        [Grammar.Reference_Terminal (Internal, "when"),
-                         Grammar.Reference_Name (Internal,
-                                         "sequence_of_identifiers")]);
-
-      Add_Non_Terminal (Grammar, "sequence_of_identifiers",
-                        New_Repeat (Grammar.Frame, Internal, False, null),
-                        Grammar.Reference_Name (Internal, "identifier"));
+                        Grammar.Reference_Name (Internal, "rule"));
 
       Add_Non_Terminal (Grammar, "rule",
                         New_Choice (Grammar.Frame, Internal),

--- a/aquarius_programs/src/aquarius-grammars.adb
+++ b/aquarius_programs/src/aquarius-grammars.adb
@@ -229,7 +229,7 @@ package body  Aquarius.Grammars is
          end if;
          Grammar.Continuation := Value (Value'First);
       else
-         Aquarius.Errors.Warning
+         Aquarius.Errors.Error
            (Declaration,
             "unknown setting: " & Name);
       end if;

--- a/docs/ebnf-grammar-syntax.md
+++ b/docs/ebnf-grammar-syntax.md
@@ -9,14 +9,17 @@ of truth; this doc describes what it accepts.
 
 ## File shape
 
-A file is a flat list of **definitions**, one per logical line. Four kinds:
+A file is a flat list of **definitions**, one per logical line. Three kinds:
 
 | Kind | Form | Purpose |
 |------|------|---------|
-| value-definition  | `name = expr`            | set a scalar property |
+| value-definition  | `name = expr`            | set a configuration property |
 | rule-definition   | `name ::= body`          | define a token or a syntax rule |
-| format-definition | `format target kw...`    | layout/pretty-print hints |
-| xref-definition   | `xref name target`       | cross-reference declaration |
+| format-definition | `.format target kw...`   | layout/pretty-print hints |
+
+The reader has no reserved words: the only keywords (`.format`, `.standard`,
+`.delimiters`) carry a leading `.` so they never collide with a rule or token
+named `format`, `standard`, etc. Everything else is a sigil.
 
 Comments are Ada-style `--` to end of line (the `.ebnf` file's own comment).
 
@@ -33,16 +36,20 @@ Comments are Ada-style `--` to end of line (the `.ebnf` file's own comment).
 
 ## Value definitions (`name = expr`)
 
-`expr` is a string, identifier, or integer. Recognised properties:
+`expr` is a string, identifier, or integer. `name` is a plain identifier drawn
+from a fixed set of configuration settings; an unrecognised name is an **error**
+(`unknown setting: <name>`). Recognised settings:
 
 ```ebnf
 case_sensitive       = false          -- keyword/identifier case folding
 line_comment         = "--"           -- start of line comment
 block_comment_start  = "(*"
 block_comment_end    = "*)"
+continuation         = "\"            -- single-char line-continuation
 ```
 
-The start symbol is a **rule**-definition named `top_level`:
+The start symbol is simply the **first** rule-definition in the file. Its name
+is arbitrary — `top_level` is a convention, nothing relies on it:
 
 ```ebnf
 top_level ::= compilation_unit
@@ -53,18 +60,18 @@ top_level ::= compilation_unit
 Rule-definitions whose body is not plain syntax define lexical classes:
 
 ```ebnf
-identifier ::= standard ada_identifier      -- use a built-in lexer
+identifier ::= .standard ada_identifier     -- use a built-in lexer
 integer    ::= !\d+!                         -- regex body
 string     ::= !\x22[^\x22]*\x22!
-delimiter  ::= delimiters "{},=:"            -- each char is its own token
+delimiter  ::= .delimiters "{},=:"           -- each char is its own token
 ```
 
 Three token-body forms:
 
-- **`standard <name>`** — a built-in lexer. Available:
+- **`.standard <name>`** — a built-in lexer. Available:
   `ada_identifier`, `ada_numeric_literal`, `ada_character_literal`,
   `ada_string_literal`, `ada_symbol`, `ada_comment`.
-- **`delimiters "<chars>"`** — declares each character in the string as a
+- **`.delimiters "<chars>"`** — declares each character in the string as a
   single-character delimiter token.
 - **regex** (`!...!`) — see below.
 
@@ -131,29 +138,17 @@ with_clause ::= 'with' < withed_unit_name : package_name / ',' > ';'
 Here each child parses as `package_name` but is labelled `withed_unit_name` in
 the tree.
 
-### `when` guard
-
-A sequence element may be guarded by a precondition:
-
-```ebnf
-some_rule ::= alternative when flag_a flag_b
-```
-
-`when` is followed by a sequence of identifiers; the alternative is only viable
-when those hold (checked via the parser's `Check_Precondition`). No example in
-the shipped grammars, but the reader accepts it.
-
 ## Format definitions
 
 Layout hints for the pretty-printer. Target is a terminal (`';'`) or a rule
 name; followed by one or more format keywords:
 
 ```ebnf
-format context_clause new_line_after
-format declarative_part indented_child
-format ';' no_space_before no_space_after new_line_after
-format '(' space_before no_space_after
-format ':' space_after space_before
+.format context_clause new_line_after
+.format declarative_part indented_child
+.format ';' no_space_before no_space_after new_line_after
+.format '(' space_before no_space_after
+.format ':' space_after space_before
 ```
 
 Keywords in use across the shipped grammars:
@@ -163,33 +158,22 @@ Keywords in use across the shipped grammars:
 · `soft_new_line_after` · `indent_before` · `outdent_after` · `indented_child` ·
 `closing`
 
-## xref definitions
-
-```ebnf
-xref <identifier> <terminal-or-rule>
-```
-
-Declares a cross-reference. Accepted by the reader; not exercised by the
-shipped grammars.
-
 ## Grammar-of-the-grammar (summary)
 
 Distilled from the bootstrap reader:
 
 ```ebnf
 source-file      ::= { definition }
-definition       ::= value-definition | format-definition
-                   | xref-definition  | rule-definition
+definition       ::= value-definition | format-definition | rule-definition
 value-definition ::= identifier '=' ( string | identifier | integer )
-format-definition::= 'format' terminal-or-rule { identifier }
-xref-definition  ::= 'xref' identifier terminal-or-rule
+format-definition::= '.format' terminal-or-rule { identifier }
 rule-definition  ::= identifier '::=' definition-body
 definition-body  ::= standard-body | delimiter-body
                    | regex | syntax-body
-standard-body    ::= 'standard' identifier
-delimiter-body   ::= 'delimiters' string
+standard-body    ::= '.standard' identifier
+delimiter-body   ::= '.delimiters' string
 syntax-body      ::= sequence-of-rules { '|' sequence-of-rules }
-sequence-of-rules::= { rule [ 'when' { identifier } ] }
+sequence-of-rules::= { rule }
 rule             ::= '{' repeater '}'          -- repeat 0+
                    | '<' repeater '>'          -- repeat 1+
                    | '[' sequence-of-rules ']' -- optional
@@ -207,16 +191,16 @@ terminal-or-rule ::= identifier | terminal
 top_level ::= json_value
 case_sensitive = false
 
-format ':' no_space_before
-format ',' no_space_before new_line_after
-format '{' new_line_after
-format '}' new_line_before
-format component_value indent_before outdent_after
+.format ':' no_space_before
+.format ',' no_space_before new_line_after
+.format '{' new_line_after
+.format '}' new_line_before
+.format component_value indent_before outdent_after
 
 identifier ::= !\l[\w_]*!
 integer    ::= !\d+!
 string     ::= !\x22[^\x22]*\x22!
-delimiter  ::= delimiters "{},=:"
+delimiter  ::= .delimiters "{},=:"
 
 json_value      ::= primitive_value | array_value | object_value
 primitive_value ::= null_value | boolean_value | integer_value | string_value

--- a/share/aquarius/grammar/ada/ada.ebnf
+++ b/share/aquarius/grammar/ada/ada.ebnf
@@ -2,53 +2,53 @@ top_level ::= compilation_unit
 
 case_sensitive = false
 
-identifier         ::= standard ada_identifier
-numeric_literal    ::= standard ada_numeric_literal
-character_literal  ::= standard ada_character_literal
-string_literal     ::= standard ada_string_literal
-delimiter          ::= delimiters "&()+,;|@[]"
-symbol             ::= standard ada_symbol
+identifier         ::= .standard ada_identifier
+numeric_literal    ::= .standard ada_numeric_literal
+character_literal  ::= .standard ada_character_literal
+string_literal     ::= .standard ada_string_literal
+delimiter          ::= .delimiters "&()+,;|@[]"
+symbol             ::= .standard ada_symbol
 
 line_comment       = "--"
 
-format context_clause new_line_after
-format declarative_part indented_child
-format sequence_of_statements indented_child
-format exception_handler indented_child
-format record_type_definition new_line_before indent_before outdent_after
-format record_component_list indented_child
-format formal_part soft_new_line
-format actual_argument_list soft_new_line
-format default_value_expression soft_new_line
-format type_definition soft_new_line
-format 'generic' new_line_after
-format generic_formal_parameter_list indented_child
-format interface_inheritance soft_new_line
-format new_generic_package soft_new_line_before
-format generic_actual_part soft_new_line_before
-format boolean_operator soft_new_line
-format relational_operator soft_new_line
-format binary_adding_operator soft_new_line
-format multiplying_operator soft_new_line
-format array_type_definition soft_new_line
+.format context_clause new_line_after
+.format declarative_part indented_child
+.format sequence_of_statements indented_child
+.format exception_handler indented_child
+.format record_type_definition new_line_before indent_before outdent_after
+.format record_component_list indented_child
+.format formal_part soft_new_line
+.format actual_argument_list soft_new_line
+.format default_value_expression soft_new_line
+.format type_definition soft_new_line
+.format 'generic' new_line_after
+.format generic_formal_parameter_list indented_child
+.format interface_inheritance soft_new_line
+.format new_generic_package soft_new_line_before
+.format generic_actual_part soft_new_line_before
+.format boolean_operator soft_new_line
+.format relational_operator soft_new_line
+.format binary_adding_operator soft_new_line
+.format multiplying_operator soft_new_line
+.format array_type_definition soft_new_line
 
-format 'return' soft_new_line space_after
-format 'then' closing space_after space_before
-format 'loop' closing space_after space_before
-format 'is' closing space_after space_before
+.format 'return' soft_new_line space_after
+.format 'then' closing space_after space_before
+.format 'loop' closing space_after space_before
+.format 'is' closing space_after space_before
 
-format ';' no_space_before no_space_after new_line_after
-format '.' no_space_before no_space_after
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format '[' space_before no_space_after
-format ']' no_space_before space_after
-format ',' no_space_before space_after
-format ''' no_space_before no_space_after
-format '=>' soft_new_line_after
-format 'with' soft_new_line_after space_after space_before
-format 'of' soft_new_line_before space_after space_before
-format ':' space_after space_before
+.format ';' no_space_before no_space_after new_line_after
+.format '.' no_space_before no_space_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format '[' space_before no_space_after
+.format ']' no_space_before space_after
+.format ',' no_space_before space_after
+.format ''' no_space_before no_space_after
+.format '=>' soft_new_line_after
+.format 'with' soft_new_line_after space_after space_before
+.format 'of' soft_new_line_before space_after space_before
+.format ':' space_after space_before
 
 compilation_unit ::= context_clause library_item
                    

--- a/share/aquarius/grammar/aqua/aqua.ebnf
+++ b/share/aquarius/grammar/aqua/aqua.ebnf
@@ -2,39 +2,39 @@ top_level ::= class_declaration
 case_sensitive = false
 
 identifier         ::= !\l[\w]*!
-integer            ::= standard ada_numeric_literal
+integer            ::= .standard ada_numeric_literal
 real               ::= ![0-9]+\.[0-9]+([eE][0-9]+)?!
 character_constant ::= !\'[.]\'!
-string_constant     ::= standard ada_string_literal
+string_constant     ::= .standard ada_string_literal
 
 line_comment = "--"
 
-format '[' space_before no_space_after
-format ']' no_space_before space_after
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format ';' no_space_before new_line_after
-format ':' space_before space_after
-format ',' no_space_before space_after
-format '.' no_space_before no_space_after
+.format '[' space_before no_space_after
+.format ']' no_space_before space_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format ';' no_space_before new_line_after
+.format ':' space_before space_after
+.format ',' no_space_before space_after
+.format '.' no_space_before no_space_after
 
-format 'end' new_line_before
-format 'local' new_line_before
+.format 'end' new_line_before
+.format 'local' new_line_before
 
-format note_list indented_child
-format inherit_list indented_child
-format feature_adaptation indented_child
-format feature_declaration_list indented_child
-format new_export_list indented_child
-format attribute indented_child
-format deferred new_line_after
-format assertion_clause indented_child
-format entity_declaration_list indented_child
-format compound indented_child
-format instruction new_line_before
-format until_expression indented_child
+.format note_list indented_child
+.format inherit_list indented_child
+.format feature_adaptation indented_child
+.format feature_declaration_list indented_child
+.format new_export_list indented_child
+.format attribute indented_child
+.format deferred new_line_after
+.format assertion_clause indented_child
+.format entity_declaration_list indented_child
+.format compound indented_child
+.format instruction new_line_before
+.format until_expression indented_child
 
-format feature_declaration new_line_before
+.format feature_declaration new_line_before
 
 class_declaration ::=
    [ notes ]

--- a/share/aquarius/grammar/idle/idle.ebnf
+++ b/share/aquarius/grammar/idle/idle.ebnf
@@ -1,22 +1,22 @@
 top_level ::= package
 case_sensitive = false
 
-identifier         ::= standard ada_identifier
-numeric_literal    ::= standard ada_numeric_literal
-character_literal  ::= standard ada_character_literal
-string_literal     ::= standard backslash_escaped_string
-delimiter          ::= delimiters "(),;[]^."
+identifier         ::= .standard ada_identifier
+numeric_literal    ::= .standard ada_numeric_literal
+character_literal  ::= .standard ada_character_literal
+string_literal     ::= .standard backslash_escaped_string
+delimiter          ::= .delimiters "(),;[]^."
 
 line_comment = "--"
 
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format ';' no_space_before new_line_after
-format ':' space_before space_after
-format ',' no_space_before space_after
-format '.' no_space_before no_space_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format ';' no_space_before new_line_after
+.format ':' space_before space_after
+.format ',' no_space_before space_after
+.format '.' no_space_before no_space_after
 
-format declaration_list indented_child
+.format declaration_list indented_child
 
 package ::= interface_declaration
 

--- a/share/aquarius/grammar/json/json.ebnf
+++ b/share/aquarius/grammar/json/json.ebnf
@@ -1,16 +1,16 @@
 top_level ::= json_value
 case_sensitive = false
 
-format ':' no_space_before
-format ',' no_space_before new_line_after
-format '{' new_line_after
-format '}' new_line_before
-format component_value indent_before outdent_after
+.format ':' no_space_before
+.format ',' no_space_before new_line_after
+.format '{' new_line_after
+.format '}' new_line_before
+.format component_value indent_before outdent_after
 
 identifier ::= !\l[\w_]*!
 integer    ::= !\d+!
 string     ::= !\x22[^\x22]*\x22!
-delimiter  ::= delimiters "{},=:"
+delimiter  ::= .delimiters "{},=:"
 
 json_value ::= primitive_value | array_value | object_value
 

--- a/share/aquarius/grammar/lox/lox.ebnf
+++ b/share/aquarius/grammar/lox/lox.ebnf
@@ -1,20 +1,20 @@
 top_level ::= expression
 case_sensitive = false
 
-identifier         ::= standard ada_identifier
-numeric_literal    ::= standard ada_numeric_literal
-character_literal  ::= standard ada_character_literal
-string_literal     ::= standard backslash_escaped_string
-delimiter          ::= delimiters "(),;[]^."
+identifier         ::= .standard ada_identifier
+numeric_literal    ::= .standard ada_numeric_literal
+character_literal  ::= .standard ada_character_literal
+string_literal     ::= .standard backslash_escaped_string
+delimiter          ::= .delimiters "(),;[]^."
 
 line_comment = "//"
 
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format ';' no_space_before new_line_after
-format ':' space_before space_after
-format ',' no_space_before space_after
-format '.' no_space_before no_space_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format ';' no_space_before new_line_after
+.format ':' space_before space_after
+.format ',' no_space_before space_after
+.format '.' no_space_before no_space_after
 
 expression ::= simple_expression [relation simple_expression]
 relation ::= '==' | '!=' | '<' | '<=' | '>' | '>='

--- a/share/aquarius/grammar/normandy/normandy.ebnf
+++ b/share/aquarius/grammar/normandy/normandy.ebnf
@@ -1,18 +1,18 @@
 top ::= package
 
-identifier ::= standard ada_identifier
-number     ::= standard ada_numeric_literal
-string     ::= standard backslash_escaped_string
-delimiter  ::= delimiters "(),;[]."
+identifier ::= .standard ada_identifier
+number     ::= .standard ada_numeric_literal
+string     ::= .standard backslash_escaped_string
+delimiter  ::= .delimiters "(),;[]."
 
 line_comment = "--"
 
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format ';' no_space_before new_line_after
-format ':' space_before space_after
-format ',' no_space_before space_after
-format '.' no_space_before no_space_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format ';' no_space_before new_line_after
+.format ':' space_before space_after
+.format ',' no_space_before space_after
+.format '.' no_space_before no_space_after
 
 package ::= 'package' package_name [ description ] declarations 'end'
 

--- a/share/aquarius/grammar/oberon/oberon.ebnf
+++ b/share/aquarius/grammar/oberon/oberon.ebnf
@@ -1,31 +1,31 @@
 top_level ::= module
 case_sensitive = true
 
-ident         ::= standard ada_identifier
+ident         ::= .standard ada_identifier
 CharConstant  ::= !('[.]')|(\d+X)!
 integer       ::= !(\d+)|([0-9a-fA-F]+H)!
-string        ::= standard backslash_escaped_string
-delimiter     ::= delimiters "(),;[]^."
+string        ::= .standard backslash_escaped_string
+delimiter     ::= .delimiters "(),;[]^."
 
 block_comment_start = "(*"
  block_comment_end   = "*)"
 
-format ';' no_space_before new_line_after
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format ',' no_space_before space_after
-format '.' no_space_before no_space_after
-format '~' no_space_after
-format '[' no_space_before no_space_after
-format ']' no_space_before
-format ':=' space_before space_after
-format '{' no_space_after
-format '}' no_space_before
+.format ';' no_space_before new_line_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format ',' no_space_before space_after
+.format '.' no_space_before no_space_after
+.format '~' no_space_after
+.format '[' no_space_before no_space_after
+.format ']' no_space_before
+.format ':=' space_before space_after
+.format '{' no_space_after
+.format '}' no_space_before
 
-format ConstantDeclaration indented_child
-format TypeDeclaration indented_child
-format VariableDeclaration indented_child
-format StatementSequence indented_child
+.format ConstantDeclaration indented_child
+.format TypeDeclaration indented_child
+.format VariableDeclaration indented_child
+.format StatementSequence indented_child
 
 qualident ::= [ident '.'] ident
 identdef ::= ident [ '*' ]

--- a/share/aquarius/grammar/pascal/pascal.ebnf
+++ b/share/aquarius/grammar/pascal/pascal.ebnf
@@ -1,26 +1,26 @@
 top_level ::= program
 case_sensitive = false
 
-identifier         ::= standard ada_identifier
-numeric_literal    ::= standard ada_numeric_literal
-character_literal  ::= standard ada_character_literal
-string_literal     ::= standard backslash_escaped_string
-delimiter          ::= delimiters "(),;[]^."
+identifier         ::= .standard ada_identifier
+numeric_literal    ::= .standard ada_numeric_literal
+character_literal  ::= .standard ada_character_literal
+string_literal     ::= .standard backslash_escaped_string
+delimiter          ::= .delimiters "(),;[]^."
 
 block_comment_start = "(*"
 block_comment_end   = "*)"
 
-format ';' no_space_before new_line_after
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format ',' no_space_before space_after
-format '.' no_space_before no_space_after
+.format ';' no_space_before new_line_after
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format ',' no_space_before space_after
+.format '.' no_space_before no_space_after
 
-format constant_definition indented_child
-format type_definition indented_child
-format variable_declaration indented_child
-format statement indented_child
-format 'end' new_line_before
+.format constant_definition indented_child
+.format type_definition indented_child
+.format variable_declaration indented_child
+.format statement indented_child
+.format 'end' new_line_before
 
 program ::= program_heading ';' program_block '.'
 

--- a/share/aquarius/grammar/wir/wir.ebnf
+++ b/share/aquarius/grammar/wir/wir.ebnf
@@ -3,27 +3,27 @@ top_level ::= unit
 case_sensitive = false
 
 identifier      ::= !\l[\w]*!
-integer         ::= standard ada_numeric_literal
-string_constant ::= standard ada_string_literal
-delimiter       ::= delimiters "()[]+,;&|"
-symbol          ::= standard ada_symbol
+integer         ::= .standard ada_numeric_literal
+string_constant ::= .standard ada_string_literal
+delimiter       ::= .delimiters "()[]+,;&|"
+symbol          ::= .standard ada_symbol
 
 line_comment = "--"
 
-format '(' space_before no_space_after
-format ')' no_space_before space_after
-format '[' space_before no_space_after
-format ']' no_space_before space_after
-format ',' no_space_before space_after
-format ':' space_before space_after
-format ';' no_space_before new_line_after
-format 'is' closing space_before new_line_after
-format 'then' closing space_before space_after
-format 'do' closing space_before space_after
-format 'end' new_line_before
-format routine new_line_before
-format statement new_line_before
-format statement_list indented_child
+.format '(' space_before no_space_after
+.format ')' no_space_before space_after
+.format '[' space_before no_space_after
+.format ']' no_space_before space_after
+.format ',' no_space_before space_after
+.format ':' space_before space_after
+.format ';' no_space_before new_line_after
+.format 'is' closing space_before new_line_after
+.format 'then' closing space_before space_after
+.format 'do' closing space_before space_after
+.format 'end' new_line_before
+.format routine new_line_before
+.format statement new_line_before
+.format statement_list indented_child
 
 unit ::= { routine } { data_item }
 


### PR DESCRIPTION
Reserved words gone. EBNF reader now has zero reserved words — 3 keywords carry a . sigil, 2 dropped.

-  ebnf.adb: format→.format, standard→.standard, delimiters→.delimiters; deleted xref-definition, optional_when, sequence_of_identifiers rules.
-  plugins-ebnf.adb: dropped xref + when action registrations.
analyse.ads/.adb: deleted After_Cross_Reference_Definition, After_When.
-  grammars.adb:232: unknown config setting Warning→Error.

Grammars: 10 .ebnf files rewritten (128 .format, 30 .standard, 9 .delimiters). 'when' quoted terminals in ada/aqua untouched — those are the target languages' own keyword, never the ebnf one.