### PR TITLE
Auto-inject earlier-stage visitor objects by field type; use it in Pa…

### DIFF
--- a/aquarius_ack/src/ack-bindings.adb
+++ b/aquarius_ack/src/ack-bindings.adb
@@ -27,6 +27,18 @@ package body Ack.Bindings is
      new WL.String_Maps
        (Ack.Classes.Constant_Class_Entity, Ack.Classes."=");
 
+   --  Maps a class's qualified name to the list of its "group reference"
+   --  attributes -- attributes whose type is another visitor class in the same
+   --  grammar (e.g. Pascal.Generate.Factor with a field of type
+   --  Pascal.Checks.Factor). Each such attribute is auto-injected, per node,
+   --  from the property bag when the class's visitor is materialised, giving a
+   --  later stage typed access to an earlier stage's object for the same node.
+   --  Kept per class (not group-global) so a class's generated _Aqua_Binding
+   --  subclass only gets setters for the attributes it actually declares.
+   package Class_Reference_Maps is
+     new WL.String_Maps
+       (List_Of_Constant_Entities.List, List_Of_Constant_Entities."=");
+
    type Implicit_Call_Record is
       record
          Feature_Name : Ada.Strings.Unbounded.Unbounded_String;
@@ -85,7 +97,7 @@ package body Ack.Bindings is
       Group             : Aquarius.Actions.Action_Group)
       return Boolean
    is
-      References     : List_Of_Constant_Entities.List;
+      Class_References : Class_Reference_Maps.Map;
       Binding_Table  : Ack.Bindings.Actions.Ack_Binding_Table;
       Binding_Vector : Binding_Record_Vectors.Vector;
       Local_Classes  : Link_Name_To_Class_Maps.Map;
@@ -113,6 +125,11 @@ package body Ack.Bindings is
            Ack.Classes.Class_Entity_Record'Class;
          Property : not null access constant Root_Entity_Type'Class)
          return Boolean;
+
+      function Refs_Of (Class_Full_Name : String)
+         return List_Of_Constant_Entities.List;
+      --  The group-reference attributes declared by the named class (empty if
+      --  none). Resolved at write time so declaration order does not matter.
 
       procedure Load_Class
         (Directory_Entry : Ada.Directories.Directory_Entry_Type);
@@ -180,7 +197,20 @@ package body Ack.Bindings is
              (Class,
               Ack.Features.Feature_Entity_Record'Class (Feature.all)'Access)
          then
-            References.Append (Constant_Entity_Type (Feature));
+            declare
+               Key : constant String := Class.Qualified_Name;
+               L   : List_Of_Constant_Entities.List;
+            begin
+               if Class_References.Contains (Key) then
+                  L := Class_References.Element (Key);
+               end if;
+               L.Append (Constant_Entity_Type (Feature));
+               if Class_References.Contains (Key) then
+                  Class_References.Replace (Key, L);
+               else
+                  Class_References.Insert (Key, L);
+               end if;
+            end;
             return;
          end if;
 
@@ -210,7 +240,8 @@ package body Ack.Bindings is
                           Child_Class          => <>,
                           Position             => Position,
                           Has_Feature_Binding  => True,
-                          References           => References,
+                          References           =>
+                            List_Of_Constant_Entities.Empty_List,
                           Implicit_Calls       => <>);
             begin
 
@@ -442,6 +473,21 @@ package body Ack.Bindings is
            and then Property_Top_Name = Class_Top_Name;
       end Is_Group_Reference;
 
+      -------------
+      -- Refs_Of --
+      -------------
+
+      function Refs_Of (Class_Full_Name : String)
+         return List_Of_Constant_Entities.List
+      is
+      begin
+         if Class_References.Contains (Class_Full_Name) then
+            return Class_References.Element (Class_Full_Name);
+         else
+            return List_Of_Constant_Entities.Empty_List;
+         end if;
+      end Refs_Of;
+
       ----------------
       -- Load_Class --
       ----------------
@@ -471,7 +517,6 @@ package body Ack.Bindings is
             Ada.Text_IO.Put_Line ("loading: " & Source_Name);
          end if;
 
-         References.Clear;
          if Tree_Name /= ""
            and then Grammar.Have_Syntax (Tree_Name)
          then
@@ -682,9 +727,12 @@ package body Ack.Bindings is
             Child_String      : constant Boolean :=
                                   Child_Name = "String";
 
+            Parent_Refs       : constant List_Of_Constant_Entities.List :=
+                                  Refs_Of (Parent_Name);
+
          begin
 
-            if not Binding.References.Is_Empty then
+            if not Parent_Refs.Is_Empty then
                declare
                   use Ada.Directories;
                   Parent_Class_File : File_Type;
@@ -700,7 +748,7 @@ package body Ack.Bindings is
                             & " inherit " & Parent_Name);
                   Put_Line (Parent_Class_File,
                             "feature");
-                  for Ref of Binding.References loop
+                  for Ref of Parent_Refs loop
                      Put_Line (Parent_Class_File,
                                "   Set_Binding_" & Ref.Declared_Name
                                & " (Item : "
@@ -731,7 +779,7 @@ package body Ack.Bindings is
             if Has_Child and then not Child_String then
                Put_Converter ("Convert_C", Child_Class_Name);
             end if;
-            for Ref of Binding.References loop
+            for Ref of Parent_Refs loop
                Put_Converter ("Convert_Ref_" & Ref.Declared_Name,
                               Class_Name =>
                                 Ref.Get_Type.Class_Context.Qualified_Name);
@@ -770,7 +818,7 @@ package body Ack.Bindings is
                end if;
             end if;
 
-            for Ref of Binding.References loop
+            for Ref of Parent_Refs loop
                Check_Class_Binding (Ref);
             end loop;
 
@@ -906,7 +954,7 @@ package body Ack.Bindings is
                if Rec.Has_Feature_Binding
                  or else not Rec.Implicit_Calls.Is_Empty
                then
-                  if not Rec.References.Is_Empty then
+                  if not Refs_Of (Parent_Name).Is_Empty then
                      Aqua_Bound_Classes.Include (Parent_Name);
                   end if;
                end if;
@@ -954,7 +1002,7 @@ package body Ack.Bindings is
 
                      if (Rec.Has_Feature_Binding
                          or else not Rec.Implicit_Calls.Is_Empty)
-                       and then not Rec.References.Is_Empty
+                       and then not Refs_Of (-Rec.Parent_Full_Name).Is_Empty
                      then
                         Load_Object_File (Name, Rec);
                      end if;

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
@@ -4,11 +4,13 @@ class
 inherit
    Pascal.Checks.Node
 
---  control_variable ::= variable_identifier (the for-loop variable). Resolve
---  it like any variable_access: pin its frame-local offset on this node as
---  "pascal.offset", or report an undeclared-variable error.
+--  control_variable ::= variable_identifier (the for-loop variable). Resolves
+--  its frame-local offset and exposes it as Offset; the code stage reads it via
+--  type-injection (#66). Undeclared name is a semantic error.
 
 feature
+
+   Offset : Integer
 
    After_Node
       local
@@ -16,7 +18,7 @@ feature
       do
          N := Concatenated_Image
          if Scope.Is_Declared (N) then
-            Set_Integer_Property ("pascal.offset", Scope.Offset (N))
+            Offset := Scope.Offset (N)
          else
             Error ("undeclared variable: " & N)
          end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
@@ -5,14 +5,16 @@ inherit
    Pascal.Checks.Node
 
 --  Top level. After the whole program has been walked (so every declaration
---  has been counted), pin the routine's local count on the program node as the
---  "pascal.locals" property for the code stage.
+--  has been counted), expose the routine's local count as Locals; the code
+--  stage's Pascal.Generate.Program reads it via type-injection (#66).
 
 feature
 
+   Locals : Integer
+
    After_Node
       do
-         Set_Integer_Property ("pascal.locals", Scope.Count)
+         Locals := Scope.Count
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -5,12 +5,14 @@ inherit
    Pascal.Checks.Node
 
 --  variable_access ::= variable_identifier { variable_suffix }. Resolves the
---  name to its frame-local offset and pins it on this node as the
---  "pascal.offset" property for the code stage to read. An undeclared name is
---  a semantic error (rather than a code-stage crash). Scalars only (suffixes
---  are out of demo scope).
+--  name to its frame-local offset and exposes it as the public Offset field.
+--  The code-stage Pascal.Generate.Variable_Access for the same node receives
+--  this object by type-injection (issue #66) and reads Offset directly. An
+--  undeclared name is a semantic error. Scalars only.
 
 feature
+
+   Offset : Integer
 
    After_Variable_Identifier (Child : Pascal.Checks.Variable_Identifier)
       do
@@ -21,7 +23,7 @@ feature
       do
          if attached Nm as N then
             if Scope.Is_Declared (N) then
-               Set_Integer_Property ("pascal.offset", Scope.Offset (N))
+               Offset := Scope.Offset (N)
             else
                Error ("undeclared variable: " & N)
             end

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-control_variable.aqua
@@ -4,18 +4,20 @@ class
 inherit
    Pascal.Generate.Node
 
---  Leaf: control_variable ::= variable_identifier. The semantic stage resolved
---  the name and pinned its frame-local offset on this node ("pascal.offset");
---  the enclosing for_statement reads it via Offset.
+--  Leaf: control_variable ::= variable_identifier. The semantic-stage
+--  Pascal.Checks.Control_Variable for this node is injected by type (#66); the
+--  enclosing for_statement reads the resolved offset via Offset.
 
 feature
+
+   Checks : detachable Pascal.Checks.Control_Variable
 
    Offset : Integer
 
    After_Node
       do
-         if Has_Node_Property ("pascal.offset") then
-            Offset := Get_Integer_Property ("pascal.offset")
+         if attached Checks as C then
+            Offset := C.Offset
          end
       end
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-program.aqua
@@ -5,16 +5,17 @@ inherit
    Pascal.Generate.Node
 
 --  Top level: program_heading ';' program_block '.'. Builds an Ast.Unit with
---  a single public routine (the program body) whose locals are the variables
---  declared in the block, then opens a Tagatha.Code, lowers the unit, and
---  disposes -- the same shape as Wir.Generate.Unit.
+--  a single public routine (the program body), opens a Tagatha.Code, lowers
+--  the unit, and disposes -- the same shape as Wir.Generate.Unit.
 --
---  The routine's local count is the "pascal.locals" property the semantic
---  stage pinned on this node. A Pascal program body has no explicit return, so
---  an implicit valueless return is appended to terminate the routine (emit its
---  epilogue).
+--  The routine's local count comes from the semantic-stage Pascal.Checks.Program
+--  for this node, injected by type (issue #66) into Checks. A Pascal program
+--  body has no explicit return, so an implicit valueless return is appended to
+--  terminate the routine (emit its epilogue).
 
 feature
+
+   Checks : detachable Pascal.Checks.Program
 
    After_Program_Heading (Child : Pascal.Generate.Program_Heading)
       do
@@ -28,20 +29,24 @@ feature
 
    After_Node
       local
-         U     : Ast.Unit
-         R     : Ast.Routine
-         Code  : Tagatha.Code
-         Seq   : Ast.Statement.Sequence
-         Ret   : Ast.Statement.Return
+         U      : Ast.Unit
+         R      : Ast.Routine
+         Code   : Tagatha.Code
+         Seq    : Ast.Statement.Sequence
+         Ret    : Ast.Statement.Return
+         Locals : Integer
       do
          if attached Nm as N then
             if attached Body as B then
+               if attached Checks as C then
+                  Locals := C.Locals
+               end
                create Seq.Make (Void, Current)
                Seq.Append (B)
                create Ret.Make (Void, Current)
                Seq.Append (Ret)
                create U.Make (Current)
-               create R.Make (Current, N, 0, Get_Integer_Property ("pascal.locals"), True, Seq)
+               create R.Make (Current, N, 0, Locals, True, Seq)
                U.Add_Routine (R)
                create Code.Make
                U.Generate (Code)

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
@@ -5,21 +5,25 @@ inherit
    Pascal.Generate.Expr_Node
 
 --  variable_access ::= variable_identifier { variable_suffix }. The semantic
---  stage already resolved the name and pinned the frame-local offset on this
---  node as the "pascal.offset" property; the code stage just reads it and
---  yields an Ast.Expression.Local_Variable (rvalue and assignment target).
+--  stage's Pascal.Checks.Variable_Access for the SAME node is injected here by
+--  type (issue #66): the framework populates Checks with that node's
+--  earlier-stage object, so the resolved offset is read as a typed field
+--  (Checks.Offset) -- no property-bag marshalling. Yields an
+--  Ast.Expression.Local_Variable (rvalue and assignment target).
 
 feature
+
+   Checks : detachable Pascal.Checks.Variable_Access
 
    After_Node
       local
          L : Ast.Expression.Local_Variable
       do
-         if Has_Node_Property ("pascal.offset") then
-            create L.Make (Void, Current, Get_Integer_Property ("pascal.offset"))
+         if attached Checks as C then
+            create L.Make (Void, Current, C.Offset)
             Set_Expr (L)
          else
-            Error ("internal: variable_access has no resolved pascal.offset")
+            Error ("internal: variable_access not resolved by semantic stage")
          end
       end
 


### PR DESCRIPTION
…scal (#66)

Compiler (ack): a later-stage visitor can now declare an attribute whose type is an earlier-stage visitor class for the same node, and the binding glue injects that object automatically -- typed access to a prior stage's result, no property-bag marshalling.

The detection (Is_Group_Reference) and injection (Set_Binding_ setters read from the node's property bag) already existed but were group-global: every generated <Parent>_Aqua_Binding got setters for every reference in the group, so any class declaring such a field broke compilation (setters referencing attributes the parent lacks). Fixed by tracking references PER CLASS (Class_References map keyed by class qualified name, resolved at write time), so a class's binding subclass gets setters only for the attributes it declares. This works because visitor objects are cached per node in Aqua_Props keyed by class name and the aqua VM is a bump allocator with no GC, so the semantic object persists into the code stage.

Pascal: the code stage now reads resolved data as typed fields off injected Pascal.Checks.* objects instead of Get_Integer_Property calls. Checks visitors expose Offset (variable_access, control_variable) and Locals (program) as public fields; Generate visitors declare a Checks reference and read it.

Verified: undeclared/duplicate still error in the semantic stage; the three samples emit byte-identical PDP-11; aqua unit suite 54/54; pascal compiles cleanly across cold-cache runs. Requires an alr rebuild (ack change).