### PR TITLE
Unit-test grammars via a test action stage (#70)

### DIFF
--- a/aquarius_base/src/aquarius-options.adb
+++ b/aquarius_base/src/aquarius-options.adb
@@ -40,6 +40,7 @@ package body Aquarius.Options is
    Code_Trigger_Option : constant String := "code trigger";
    Start_Class_Option  : constant String := "start class";
    Check_File_Option   : constant String := "check file";
+   Test_File_Option    : constant String := "test file";
    Self_Test_Option    : constant String := "self test";
    Clear_Cache_Option  : constant String := "clear cache";
    Help_Option         : constant String := "help";
@@ -114,6 +115,15 @@ package body Aquarius.Options is
       return Bool_Values (Clear_Cache_Option);
    end Clear_Cache;
 
+   ---------------
+   -- Test_File --
+   ---------------
+
+   function Test_File return String is
+   begin
+      return Str_Values (Test_File_Option);
+   end Test_File;
+
    ------------------
    -- Code_Trigger --
    ------------------
@@ -170,6 +180,9 @@ package body Aquarius.Options is
                   Str_Kind);
       Add_Option (Check_File_Option, "check",
                   "Load a file, report any errors, and exit", Str_Kind);
+      Add_Option (Test_File_Option, "test",
+                  "Load a file, run the grammar's test actions, and exit",
+                  Str_Kind);
       Add_Option (Self_Test_Option, "self-test",
                   "Run unit tests", Bool_Kind);
       Add_Option (Clear_Cache_Option, "clear-cache",

--- a/aquarius_base/src/aquarius-options.ads
+++ b/aquarius_base/src/aquarius-options.ads
@@ -5,6 +5,8 @@ package Aquarius.Options is
    function Start_Class return String;
 
    function Check_File return String;
+
+   function Test_File return String;
    --  path of a file to load and check for errors; empty if not given
 
    function Source_File_Count return Natural;

--- a/aquarius_syntax/src/aquarius-actions.ads
+++ b/aquarius_syntax/src/aquarius-actions.ads
@@ -30,6 +30,13 @@ package Aquarius.Actions is
    --  Code_Trigger: the action is executed in order to generate
    --  code for the tree.
 
+   --  Code_Trigger: (see above).
+
+   --  Test_Trigger: the action inspects the tree and the semantic
+   --  results (e.g. the recorded declarations and cross references) and
+   --  reports failures as error messages. Run after Semantic_Trigger by
+   --  the --test driver mode; not part of normal compilation.
+
    --  Manual_Trigger: the action can only be executed manually.
 
    --  More on Parse_Trigger actions: these actions are generally
@@ -56,6 +63,7 @@ package Aquarius.Actions is
       Semantic_Trigger,
       Project_Trigger,
       Code_Trigger,
+      Test_Trigger,
       Manual_Trigger);
 
    type Action_Position is private;

--- a/share/aquarius/grammar/ada/ada.json
+++ b/share/aquarius/grammar/ada/ada.json
@@ -6,6 +6,10 @@
         {
             "name": "checks",
             "stage": "semantic"
+        },
+        {
+            "name": "test",
+            "stage": "test"
         }
     ]
 }

--- a/share/aquarius/grammar/ada/aqua/ada-test-compilation_unit.aqua
+++ b/share/aquarius/grammar/ada/aqua/ada-test-compilation_unit.aqua
@@ -1,0 +1,58 @@
+class
+   Ada.Test.Compilation_Unit
+
+inherit
+   Aquarius.Trees.Program_Tree
+   Aquarius.Entities.Node
+   Aqua.Text_IO
+
+--  Test-stage visitor bound to the top node. Runs under Test_Trigger, after
+--  the semantic stage has populated the shared Aquarius.Entities.Environment.
+--  It walks the recorded declarations and cross references, prints each, and
+--  fails via Error (which the --test driver reports and turns into a non-zero
+--  exit status) if nothing was recorded. Because the test runs in the same
+--  plugin VM as the semantic actions, it sees the very Environment they built.
+
+feature
+
+   After_Node
+      local
+         Decl_Cursor : Aqua.Containers.Linked_List_Iterator
+                          [Aquarius.Entities.Declaration]
+         Ref_Cursor  : Aqua.Containers.Linked_List_Iterator
+                          [Aquarius.Entities.Reference]
+         Decl_Count  : Integer
+         Ref_Count   : Integer
+      do
+         from
+            Decl_Cursor := Environment.Declarations.New_Cursor
+         until
+            Decl_Cursor.After
+         loop
+            Decl_Count := Decl_Count + 1
+            Put_Line ("declaration: " & Decl_Cursor.Element.Qualified_Name
+                      & " [" & Decl_Cursor.Element.Category & "]")
+            Decl_Cursor.Next
+         end
+
+         from
+            Ref_Cursor := Environment.References.New_Cursor
+         until
+            Ref_Cursor.After
+         loop
+            Ref_Count := Ref_Count + 1
+            Put_Line ("cross reference: " & Ref_Cursor.Element.Reference_Type
+                      & " at "
+                      & Ref_Cursor.Element.Reference_Tree.Start_Location_Image)
+            Ref_Cursor.Next
+         end
+
+         Put_Line ("recorded " & Decl_Count.To_String & " declarations, "
+                   & Ref_Count.To_String & " cross references")
+
+         if Decl_Count = 0 then
+            Error ("no declarations were recorded")
+         end
+      end
+
+end

--- a/share/aquarius/grammar/ada/aqua/ada-test.aqua
+++ b/share/aquarius/grammar/ada/aqua/ada-test.aqua
@@ -1,0 +1,2 @@
+class Ada.Test
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-assignment_statement.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-assignment_statement.aqua
@@ -1,0 +1,20 @@
+class
+   Pascal.Checks.Assignment_Statement
+
+inherit
+   Pascal.Checks.Node
+
+--  assignment_statement ::= variable_access ':=' expression. Marks the
+--  left-hand variable_access as an assignment target before it reduces, so the
+--  cross reference it records is classified as a write rather than a read. The
+--  Before hook fires before the child subtree (and its After_Node, where the
+--  reference is recorded) runs.
+
+feature
+
+   Before_Variable_Access (Child : Pascal.Checks.Variable_Access)
+      do
+         Child.Set_Target
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
@@ -19,6 +19,8 @@ feature
          N := Concatenated_Image
          if Scope.Is_Declared (N) then
             Offset := Scope.Offset (N)
+            --  The for-loop control variable is written by the loop.
+            Refer (Current, "write", Scope.Find_Declaration (N))
          else
             Error ("undeclared variable: " & N)
          end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -3,10 +3,14 @@ class
 
 inherit
    Aquarius.Trees.Program_Tree
+   Aquarius.Entities.Node
 
 --  Base for the semantic-stage visitors. Inheriting Program_Tree provides
 --  Concatenated_Image, Error, and the node property bag (Set_Integer_Property
 --  / Get_Integer_Property) used to hand resolved offsets to the code stage.
+--  Inheriting Aquarius.Entities.Node provides the shared Environment and Refer,
+--  so declarations and cross references are recorded in the standard entity
+--  model (readable by the test stage and, eventually, the UI).
 --
 --  Scope is the single shared symbol table for the compilation, a once value
 --  so every visitor sees the same instance. Declarations populate it (they

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -19,6 +19,7 @@ feature
    Make
       do
          create Names
+         create Declarations
          Count := 0
       end
 
@@ -70,8 +71,39 @@ feature
          end
       end
 
+   Add_Declaration (Declaration : Aquarius.Entities.Declaration)
+      do
+         Declarations.Append (Declaration)
+      end
+
+   Find_Declaration (Name : String)
+      : detachable Aquarius.Entities.Declaration
+      local
+         It    : Aqua.Containers.Linked_List_Iterator
+                    [Aquarius.Entities.Declaration]
+         Cand  : Aquarius.Entities.Declaration
+         Key   : String
+         Found : Boolean
+      do
+         Key := Name.To_Lower
+         from
+            It := Declarations.New_Cursor
+         until
+            It.After or else Found
+         loop
+            Cand := It.Element
+            if Cand.Name.To_Lower.Equal (Key) then
+               Result := Cand
+               Found := True
+            end
+            It.Next
+         end
+      end
+
 feature { None }
 
    Names : Aqua.Containers.Linked_List [String]
+
+   Declarations : Aqua.Containers.Linked_List [Aquarius.Entities.Declaration]
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -14,6 +14,13 @@ feature
 
    Offset : Integer
 
+   Is_Target : Boolean
+
+   Set_Target
+      do
+         Is_Target := True
+      end
+
    After_Variable_Identifier (Child : Pascal.Checks.Variable_Identifier)
       do
          Nm := Child.Concatenated_Image
@@ -24,6 +31,14 @@ feature
          if attached Nm as N then
             if Scope.Is_Declared (N) then
                Offset := Scope.Offset (N)
+               --  Record a cross reference to the declared variable: a write
+               --  when this access is an assignment target (flagged by the
+               --  enclosing assignment_statement), otherwise a read.
+               if Is_Target then
+                  Refer (Current, "write", Scope.Find_Declaration (N))
+               else
+                  Refer (Current, "read", Scope.Find_Declaration (N))
+               end
             else
                Error ("undeclared variable: " & N)
             end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
@@ -15,6 +15,7 @@ feature
          It     : Aqua.Containers.Linked_List_Iterator [String]
          Name   : String
          Ignore : Integer
+         Decl   : Aquarius.Entities.Declaration
       do
          from
             It := Child.Names.New_Cursor
@@ -26,6 +27,11 @@ feature
                Error ("duplicate declaration: " & Name)
             else
                Ignore := Scope.Declare (Name)
+               --  Record the variable in the standard entity model, keyed
+               --  in the scope so a later access can resolve and refer to it.
+               create Decl.Make (Name, Name, "variable", Current)
+               Environment.Add_Declaration (Decl)
+               Scope.Add_Declaration (Decl)
             end
             It.Next
          end

--- a/share/aquarius/grammar/pascal/aqua/pascal-test-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-test-program.aqua
@@ -1,0 +1,76 @@
+class
+   Pascal.Test.Program
+
+inherit
+   Aquarius.Trees.Program_Tree
+   Aquarius.Entities.Node
+   Aqua.Text_IO
+
+--  Test-stage visitor bound to the top node. Runs under Test_Trigger, after
+--  the semantic stage has populated the shared Aquarius.Entities.Environment.
+--  It walks the recorded declarations and cross references, prints each, and
+--  fails via Error (turned into a non-zero exit by the --test driver) if no
+--  declarations or no cross references were recorded. Because it runs in the
+--  same plugin VM as the semantic actions, it sees the Environment they built.
+
+feature
+
+   After_Node
+      local
+         Decl_Cursor : Aqua.Containers.Linked_List_Iterator
+                          [Aquarius.Entities.Declaration]
+         Ref_Cursor  : Aqua.Containers.Linked_List_Iterator
+                          [Aquarius.Entities.Reference]
+         Decl_Count  : Integer
+         Ref_Count   : Integer
+      do
+         from
+            Decl_Cursor := Environment.Declarations.New_Cursor
+         until
+            Decl_Cursor.After
+         loop
+            Decl_Count := Decl_Count + 1
+            Put_Line ("declaration: " & Decl_Cursor.Element.Qualified_Name
+                      & " [" & Decl_Cursor.Element.Category & "]")
+            Decl_Cursor.Next
+         end
+
+         from
+            Ref_Cursor := Environment.References.New_Cursor
+         until
+            Ref_Cursor.After
+         loop
+            Ref_Count := Ref_Count + 1
+            Put_Line ("cross reference: " & Ref_Cursor.Element.Reference_Type
+                      & " -> " & Referenced_Name (Ref_Cursor.Element)
+                      & " at " & Reference_Location (Ref_Cursor.Element))
+            Ref_Cursor.Next
+         end
+
+         Put_Line ("recorded " & Decl_Count.To_String & " declarations, "
+                   & Ref_Count.To_String & " cross references")
+
+         if Decl_Count = 0 then
+            Error ("no declarations were recorded")
+         end
+
+         if Ref_Count = 0 then
+            Error ("no cross references were recorded")
+         end
+      end
+
+   Referenced_Name (Reference : Aquarius.Entities.Reference) : String
+      do
+         if attached Reference.Declaration as D then
+            Result := D.Qualified_Name
+         else
+            Result := "<unresolved>"
+         end
+      end
+
+   Reference_Location (Reference : Aquarius.Entities.Reference) : String
+      do
+         Result := Reference.Reference_Tree.Start_Location_Image
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-test.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-test.aqua
@@ -1,0 +1,2 @@
+class Pascal.Test
+end

--- a/share/aquarius/grammar/pascal/pascal.json
+++ b/share/aquarius/grammar/pascal/pascal.json
@@ -8,6 +8,10 @@
             "stage": "semantic"
         },
         {
+            "name": "test",
+            "stage": "test"
+        },
+        {
             "name": "generate",
             "stage": "code"
         }

--- a/share/aquarius/tests/ada/test_xref.ads
+++ b/share/aquarius/tests/ada/test_xref.ads
@@ -1,0 +1,5 @@
+package Test_Xref is
+   procedure Alpha;
+   procedure Beta;
+   function Gamma return Integer;
+end Test_Xref;

--- a/share/aquarius/tests/pascal/test_xref.pas
+++ b/share/aquarius/tests/pascal/test_xref.pas
@@ -1,0 +1,9 @@
+program Test_Xref;
+var
+   i : Integer;
+   total : Integer;
+begin
+   total := 0;
+   for i := 1 to 10 do
+      total := total + i;
+end.

--- a/src/aquarius-driver.adb
+++ b/src/aquarius-driver.adb
@@ -159,6 +159,60 @@ begin
       end if;
    end;
 
+   declare
+      Test_Path : constant String := Aquarius.Options.Test_File;
+   begin
+      if Test_Path /= "" then
+         declare
+            use type Aquarius.Grammars.Aquarius_Grammar;
+            use Aquarius.Messages;
+            Grammar : constant Aquarius.Grammars.Aquarius_Grammar :=
+              Aquarius.Grammars.Manager.Get_Grammar_For_File
+                (File_Name => Test_Path);
+         begin
+            if Grammar = null then
+               Ada.Text_IO.Put_Line
+                 (Ada.Text_IO.Standard_Error,
+                  Test_Path & ": no grammar found");
+               Ada.Command_Line.Set_Exit_Status (1);
+            elsif not Aquarius.Plugins.Manager.Load (Grammar) then
+               Ada.Command_Line.Set_Exit_Status (1);
+            else
+               declare
+                  Source : constant Aquarius.Sources.Source_Reference :=
+                    Aquarius.Sources.Files.File_Source (Test_Path);
+                  Stream : constant Aquarius.Streams.Reader_Reference :=
+                    Aquarius.Streams.Files.File_Reader (Test_Path);
+                  Program : constant Aquarius.Programs.Program_Tree :=
+                    Aquarius.Reader.Read
+                      (Grammar => Grammar,
+                       Source  => Source,
+                       Stream  => Stream);
+                  List : Message_List;
+               begin
+                  --  Run the semantic checks to populate the entity model,
+                  --  then run the test actions, which inspect the recorded
+                  --  declarations and cross references and attach any failure
+                  --  messages to the tree.
+                  Grammar.Run_Action_Trigger
+                    (Program, Aquarius.Actions.Semantic_Trigger);
+                  Grammar.Run_Action_Trigger
+                    (Program, Aquarius.Actions.Test_Trigger);
+                  Program.Get_Messages (List);
+                  Aquarius.Messages.Console.Show_Messages (List);
+                  if Highest_Level (List) > Warning then
+                     Ada.Command_Line.Set_Exit_Status (1);
+                  else
+                     Ada.Text_IO.Put_Line (Test_Path & ": tests passed");
+                  end if;
+               end;
+            end if;
+         end;
+         Aquarius.Library.Shut_Down;
+         return;
+      end if;
+   end;
+
    if Aquarius.Options.Source_File_Count > 0 then
       for I in 1 .. Aquarius.Options.Source_File_Count loop
          declare


### PR DESCRIPTION
## What
Add the ability to unit-test a grammar: load a source file, run its semantic actions, and assert that declarations and cross references were recorded — via a new `--test <file>` driver mode and a `test` action stage.

## Why
Closes #70. Previously there was no way to drive a grammar over a source file and inspect what its actions recorded. Each grammar plugin runs in its own aqua VM, and `--start-class` tests run in a *separate* VM, so an aqua test cannot see the `Aquarius.Entities.Environment` (a system-wide `once`) that a grammar run populates. The fix runs the test **in the same plugin VM** as the semantic actions, so it reads the very Environment they built — no native store, no shared-VM change. This keeps the entity model pure-aqua (also usable by an aqua-driven UI the same way).

## How
- New `Test_Trigger` in `Action_Execution_Trigger`. Stage->trigger is generic (`'Value(stage & "_Trigger")`), so a `{"name":"test","stage":"test"}` group needs no further plumbing.
- New `--test` option + driver mode (mirrors `--check`): parse -> `Semantic_Trigger` -> `Test_Trigger` -> report messages, exit status from the highest message level.
- Per grammar: a `test` group whose top-node visitor inherits `Aquarius.Entities.Node`, walks `Environment.Declarations`/`.References`, prints each (with source location), and fails via `Error` if nothing was recorded.

## Changes
- **Harness**: `aquarius-actions.ads` (`Test_Trigger`), `aquarius-options.ads/.adb` (`--test`), `aquarius-driver.adb` (`--test` mode).
- **Ada**: `ada.json` test group + `ada-test.aqua`, `ada-test-compilation_unit.aqua`.
- **Pascal wired to the entity model**: `Pascal.Checks.Node` also inherits `Aquarius.Entities.Node`; `Pascal.Checks.Scope` gains a declaration list + `Find_Declaration`; `variable_declaration` records a `Declaration` per variable; `variable_access` records a `read` reference (or `write` when it is an assignment target, flagged by a new `Pascal.Checks.Assignment_Statement.Before_Variable_Access` hook); `control_variable` records a `write`. Offset/codegen path unchanged.
- `pascal.json` test group + `pascal-test.aqua`, `pascal-test-program.aqua`.
- Samples: `tests/ada/test_xref.ads`, `tests/pascal/test_xref.pas`.

## Verification (run from repo root)
`alr build` clean. `bin/aquarius --test tests/pascal/test_xref.pas`:
```
declaration: i [variable]
declaration: total [variable]
cross reference: write -> total at test_xref.pas:6:4
cross reference: write -> i at test_xref.pas:7:8
cross reference: write -> total at test_xref.pas:8:7
cross reference: read -> total at test_xref.pas:8:16
cross reference: read -> i at test_xref.pas:8:24
recorded 2 declarations, 5 cross references
tests passed
```
Failure path proven (a file recording nothing exits 1). Regressions green: Pascal `--check`, Pascal `--code-trigger` (still emits PDP-11), Ada `--check`/`--test`.

## Notes
- Depends on #69 (merged into this branch).
- Ada `Refer` path is weak, so Ada records declarations but few/no cross references; Pascal exercises both.
- Assertions are currently generic ("recorded > 0") plus a printed dump; specific per-file expected-entity assertions are a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
