### PR TITLE
feat: implement negative integer literals (#19)

### DIFF
--- a/aquarius_ack/src/ack-generate.adb
+++ b/aquarius_ack/src/ack-generate.adb
@@ -526,10 +526,23 @@ package body Ack.Generate is
                      end;
 
                   when N_Integer_Constant =>
-                     Unit.Push_Constant
-                       (Tagatha.Word_64'Value
-                          (To_String
-                               (Get_Name (Value))));
+                     declare
+                        use type Tagatha.Int_64;
+                        Text : constant String :=
+                                 To_String (Get_Name (Value));
+                     begin
+                        if Text (Text'First) = '-' then
+                           --  the target word is 32 bits wide, so push the
+                           --  two's complement pattern rather than a
+                           --  64 bit sign extension
+                           Unit.Push_Constant
+                             (Tagatha.Word_64
+                                (Tagatha.Int_64'Value (Text) mod 2 ** 32));
+                        else
+                           Unit.Push_Constant
+                             (Tagatha.Word_64'Value (Text));
+                        end if;
+                     end;
                   when N_Boolean_Constant =>
                      Unit.Push_Constant
                        (Tagatha.Int_32'
@@ -933,10 +946,14 @@ package body Ack.Generate is
 
                if Entity.Intrinsic then
                   declare
+                     --  a zero argument intrinsic, such as Integer.One or
+                     --  Integer.Negate, has no actual list at all
                      Arg_Count : constant Natural :=
-                                   Natural
-                                     (List_Table.Element (Actual_List)
-                                      .List.Length);
+                                   (if Actual_List = No_List
+                                    then 0
+                                    else Natural
+                                      (List_Table.Element (Actual_List)
+                                       .List.Length));
                      Args      : Array_Of_Nodes (1 .. Arg_Count);
                      Index     : Natural := 0;
 
@@ -952,10 +969,12 @@ package body Ack.Generate is
                      end Push;
 
                   begin
-                     for Arg of List_Table.Element (Actual_List).List loop
-                        Index := Index + 1;
-                        Args (Index) := Arg;
-                     end loop;
+                     if Actual_List /= No_List then
+                        for Arg of List_Table.Element (Actual_List).List loop
+                           Index := Index + 1;
+                           Args (Index) := Arg;
+                        end loop;
+                     end if;
                      pragma Assert (Index = Arg_Count);
 
                      for Item of Pending loop

--- a/aquarius_ack/src/ack-parser-expressions.adb
+++ b/aquarius_ack/src/ack-parser-expressions.adb
@@ -23,6 +23,14 @@ package body Ack.Parser.Expressions is
      (From : Aquarius.Programs.Program_Tree)
       return Node_Id;
 
+   function Signed_Integer_Constant
+     (Node     : Node_Id;
+      Negative : Boolean)
+      return Node_Id;
+   --  If Node is an integer manifest constant, return an equivalent
+   --  constant node with Negative applied to its literal text.  Otherwise
+   --  return No_Node.
+
    function Import_Actual_List
      (From : Aquarius.Programs.Program_Tree)
       return Node_Id
@@ -66,6 +74,28 @@ package body Ack.Parser.Expressions is
       Node := Import_Sub_Expression (Children (Index));
       Index := Index + 1;
 
+      if Prefix /= null then
+         --  a prefix operator binds tighter than the infix operators of the
+         --  same rule, so it applies to the first sub-expression only
+         declare
+            Operator : constant String := Prefix.Concatenate_Children;
+            Folded   : constant Node_Id :=
+                         (if Operator = "-" or else Operator = "+"
+                          then Signed_Integer_Constant
+                            (Node, Negative => Operator = "-")
+                          else No_Node);
+         begin
+            if Folded /= No_Node then
+               --  a signed integer literal; no operator call required
+               Node := Folded;
+            else
+               Node := New_Node (N_Operator, Prefix,
+                                 Field_1 => Node,
+                                 Name    => Get_Name_Id (Operator));
+            end if;
+         end;
+      end if;
+
       while Index <= Children'Last loop
          declare
             Operator : constant Program_Tree := Children (Index);
@@ -82,13 +112,6 @@ package body Ack.Parser.Expressions is
                                 Get_Name_Id (Operator.Concatenate_Children));
          end;
       end loop;
-
-      if Prefix /= null then
-         Node := New_Node (N_Operator, From,
-                           Field_1 => Node,
-                           Name    =>
-                             Get_Name_Id (Prefix.Concatenate_Children));
-      end if;
 
       return Node;
    end Generic_Import;
@@ -318,5 +341,48 @@ package body Ack.Parser.Expressions is
          return No_Node;
       end if;
    end Import_Primary;
+
+   -----------------------------
+   -- Signed_Integer_Constant --
+   -----------------------------
+
+   function Signed_Integer_Constant
+     (Node     : Node_Id;
+      Negative : Boolean)
+      return Node_Id
+   is
+   begin
+      if Kind (Node) /= N_Constant then
+         return No_Node;
+      end if;
+
+      declare
+         Value : constant Node_Id := Constant_Value (Node);
+      begin
+         if Kind (Value) /= N_Integer_Constant then
+            return No_Node;
+         end if;
+
+         declare
+            Text        : constant String := To_String (Get_Name (Value));
+            First_Digit : constant Positive :=
+                            (if Text (Text'First) in '+' | '-'
+                             then Text'First + 1
+                             else Text'First);
+            Is_Negative : constant Boolean :=
+                            (Text (Text'First) = '-') /= Negative;
+            Image       : constant String :=
+                            (if Is_Negative then "-" else "")
+                            & Text (First_Digit .. Text'Last);
+         begin
+            return New_Node
+              (N_Constant, Get_Program (Node),
+               Field_2 =>
+                 New_Node
+                   (N_Integer_Constant, Get_Program (Value),
+                    Name => Get_Name_Id (Image)));
+         end;
+      end;
+   end Signed_Integer_Constant;
 
 end Ack.Parser.Expressions;

--- a/share/aquarius/lib/aqua/standard/aqua-algebra-additive.aqua
+++ b/share/aquarius/lib/aqua/standard/aqua-algebra-additive.aqua
@@ -16,7 +16,7 @@ feature
          Result := Add (Right.Negate)
       end
    
-   Negate : Additive
+   Negate alias "-": like Current
       do
          Result := Zero.Subtract (Current)
       end

--- a/share/aquarius/lib/aqua/standard/integer.aqua
+++ b/share/aquarius/lib/aqua/standard/integer.aqua
@@ -69,10 +69,8 @@ feature
    LT (Right : Integer) : Boolean external "intrinsic"
 
    Minimum : Integer
-      local
-         Zero : Integer
       do
-         Result := Zero - Maximum - 1
+         Result := -2147483648
       end
 
    Maximum : Integer

--- a/share/aquarius/tests/aqua/test.aqua
+++ b/share/aquarius/tests/aqua/test.aqua
@@ -82,6 +82,8 @@ feature
          Test_List.Append (T)
          create { Test_Integer_To_String } T
          Test_List.Append (T)
+         create { Test_Negative_Literals } T
+         Test_List.Append (T)
          create { Test_Bag_Linked_List } T
          Test_List.Append (T)
          create { Test_Sequence_Linked_List } T

--- a/share/aquarius/tests/aqua/test_integer_to_string.aqua
+++ b/share/aquarius/tests/aqua/test_integer_to_string.aqua
@@ -29,7 +29,7 @@ feature
             Fail_Message := "0.To_String expected ""0"", found " & Zero.To_String
          end
 
-         Neg := Zero - 7
+         Neg := -7
          if Success and then Neg.To_String /= "-7" then
             Success := False
             Fail_Message := "(-7).To_String expected ""-7"", found " & Neg.To_String

--- a/share/aquarius/tests/aqua/test_negative_literals.aqua
+++ b/share/aquarius/tests/aqua/test_negative_literals.aqua
@@ -1,0 +1,88 @@
+class
+   Test_Negative_Literals
+
+inherit
+   Unit_Test
+
+feature
+
+   Name : String
+      do
+         Result := "test-negative-literals"
+      end
+
+   Execute
+      local
+         Zero, X, A, R, Min, Neg : Integer
+      do
+         Success := True
+         Zero := 0
+         X := 5
+
+         Neg := -1
+         if Neg.To_String /= "-1" then
+            Success := False
+            Fail_Message := "-1 expected ""-1"", found " & Neg.To_String
+         end
+
+         --  -0 is just 0
+         Neg := -0
+         if Success and then Neg /= Zero then
+            Success := False
+            Fail_Message := "-0 expected 0, found " & Neg.To_String
+         end
+
+         --  the most negative value cannot be written as a negation of a
+         --  positive literal, so it only works as a literal
+         Min := -2147483648
+         if Success and then Min /= Zero.Minimum then
+            Success := False
+            Fail_Message := "-2147483648 expected Minimum, found " & Min.To_String
+         end
+
+         --  a prefix minus binds tighter than a binary +, so this is
+         --  (-X) + 7 and not -(X + 7)
+         R := -X + 7
+         if Success and then R /= 2 then
+            Success := False
+            Fail_Message := "-X + 7 expected 2, found " & R.To_String
+         end
+
+         --  prefix minus on a call, through the Negate alias
+         R := -X
+         if Success and then R.To_String /= "-5" then
+            Success := False
+            Fail_Message := "-X expected ""-5"", found " & R.To_String
+         end
+
+         R := -Zero.Maximum
+         if Success and then R /= Min + 1 then
+            Success := False
+            Fail_Message := "-Maximum expected Minimum+1, found " & R.To_String
+         end
+
+         --  regression: negating a folded constant used to be off by one
+         R := -Zero.One
+         if Success and then R /= -1 then
+            Success := False
+            Fail_Message := "-One expected -1, found " & R.To_String
+         end
+
+         --  a negative literal as an operand of a later operator
+         A := -3
+         R := A * 4
+         if Success and then R /= -12 then
+            Success := False
+            Fail_Message := "-3 * 4 expected -12, found " & R.To_String
+         end
+
+         --  a negative literal as an argument; note that X * -3 is a syntax
+         --  error, since a unary sign only starts a simple_expression
+         R := X * (-3)
+         if Success and then R /= -15 then
+            Success := False
+            Fail_Message := "X * (-3) expected -15, found " & R.To_String
+         end
+      end
+
+end


### PR DESCRIPTION
A sign on an integer literal is now folded into the literal itself at parse-import time, so `-1` no longer reports `undeclared: -`.  Folding rather than negating is what makes `-2147483648` expressible: it cannot be produced by negating a positive literal.

Ack.Parser.Expressions.Generic_Import now applies a prefix operator to the first sub-expression instead of to the whole infix chain, so a unary sign binds tighter than the binary adding operators: `-X + 7` is `(-X) + 7`, not `-(X + 7)`.  Prefix `-` on anything other than a literal resolves through the new `Negate alias "-"` in Aqua.Algebra.Additive, whose result type becomes `like Current` for consistency with Add and Subtract.

Codegen pushed integer literals with Word_64'Value, which raises on a signed image; negatives now push the 32 bit two's complement pattern. A zero-argument intrinsic reached as a precursor element (Zero.One, X.Negate) crashed Generate_Precursor, which read Arg_Count from List_Table.Element (No_List); that path is now guarded, since prefix minus on such a call goes through it.

Integer.Minimum drops its `Zero - Maximum - 1` workaround.

Refs #92 for the remaining half of the literal typing problem: a literal in operator receiver position (`1 + X`) still fails.