### PR TITLE
fix: typecheck an integer literal in operator receiver position (#92)

### DIFF
--- a/aquarius_ack/src/ack-semantic-analysis-expressions.adb
+++ b/aquarius_ack/src/ack-semantic-analysis-expressions.adb
@@ -164,12 +164,51 @@ package body Ack.Semantic.Analysis.Expressions is
       Left      : constant Node_Id := Field_1 (Operator_Node);
       Right     : constant Node_Id := Field_2 (Operator_Node);
       Left_Type : Ack.Types.Type_Entity;
+
+      function Left_Expected_Type return Ack.Types.Type_Entity;
+
+      ------------------------
+      -- Left_Expected_Type --
+      ------------------------
+
+      function Left_Expected_Type return Ack.Types.Type_Entity is
+         Value : constant Node_Id :=
+                   (if Kind (Left) = N_Constant
+                    then Constant_Value (Left)
+                    else No_Node);
+      begin
+         if Value = No_Node
+           or else Kind (Value) /= N_Integer_Constant
+         then
+            --  string, character and boolean constants type themselves, and
+            --  any other expression carries its own type, so ANY is enough
+            return Types.Type_Any;
+         elsif Expression_Type /= null
+           and then Expression_Type.Conforms_To (Types.Type_Integral (Left))
+           and then not Expression_Type.Deferred
+           and then not Ack.Types.Type_Entity
+                          (Expression_Type).Is_Generic_Formal_Type
+         then
+            --  the literal takes the type of its context, so that e.g. a
+            --  Word_32 destination resolves the operator on Word_32
+            return Ack.Types.Type_Entity (Expression_Type);
+         else
+            --  no usable context type (ANY, BOOLEAN, a deferred type or a
+            --  generic formal), so give the literal the default integer type
+            return Types.Type_Integer;
+         end if;
+      end Left_Expected_Type;
+
    begin
+      --  An integer literal takes its type from context (see the
+      --  N_Integer_Constant case in Analyse_Expression), so a literal in
+      --  receiver position has to be handed a concrete integral type, or the
+      --  alias lookup below finds no operator on ANY.
       Analyse_Expression
         (Class           => Class,
          Container       => Container,
          Attachment      => Attachment,
-         Expression_Type => Types.Type_Any,
+         Expression_Type => Left_Expected_Type,
          Expression      => Left);
       Left_Type := Ack.Types.Type_Entity (Get_Type (Left));
 

--- a/aquarius_ack/src/ack-semantic-types.adb
+++ b/aquarius_ack/src/ack-semantic-types.adb
@@ -18,6 +18,9 @@ package body Ack.Semantic.Types is
    function Type_Character return Ack.Types.Type_Entity
    is (Get_Top_Level_Type ("character"));
 
+   function Type_Integer return Ack.Types.Type_Entity
+   is (Get_Top_Level_Type ("integer"));
+
    function Type_String return Ack.Types.Type_Entity
    is (Get_Top_Level_Type ("string"));
 

--- a/aquarius_ack/src/ack-semantic-types.ads
+++ b/aquarius_ack/src/ack-semantic-types.ads
@@ -6,6 +6,8 @@ private package Ack.Semantic.Types is
 
    function Type_Integral (Node : Node_Id) return Ack.Types.Type_Entity;
 
+   function Type_Integer return Ack.Types.Type_Entity;
+
    function Type_String return Ack.Types.Type_Entity;
 
    function Type_Character return Ack.Types.Type_Entity;

--- a/share/aquarius/tests/aqua/test.aqua
+++ b/share/aquarius/tests/aqua/test.aqua
@@ -84,6 +84,8 @@ feature
          Test_List.Append (T)
          create { Test_Negative_Literals } T
          Test_List.Append (T)
+         create { Test_Literal_Receiver } T
+         Test_List.Append (T)
          create { Test_Bag_Linked_List } T
          Test_List.Append (T)
          create { Test_Sequence_Linked_List } T

--- a/share/aquarius/tests/aqua/test_integer_add_properties.aqua
+++ b/share/aquarius/tests/aqua/test_integer_add_properties.aqua
@@ -41,7 +41,7 @@ feature
          end
 
          --  additive inverse: A + (0 - A) = 0
-         S := Zero - A
+         S := 0 - A
          R := A + S
          if Success and then R /= Zero then
             Success := False
@@ -49,7 +49,7 @@ feature
          end
 
          --  subtraction as addition of the negation: A - B = A + (0 - B)
-         S := Zero - B
+         S := 0 - B
          if Success and then A - B /= A + S then
             Success := False
             Fail_Message := "A - B /= A + (0 - B)"

--- a/share/aquarius/tests/aqua/test_integer_minimum.aqua
+++ b/share/aquarius/tests/aqua/test_integer_minimum.aqua
@@ -33,7 +33,7 @@ feature
          end
 
          --  Minimum = -(Maximum) - 1 for two's-complement 32-bit
-         if Success and then Min /= Zero - Max - One then
+         if Success and then Min /= 0 - Max - 1 then
             Success := False
             Fail_Message := "Minimum expected -(Maximum)-1"
          end

--- a/share/aquarius/tests/aqua/test_literal_receiver.aqua
+++ b/share/aquarius/tests/aqua/test_literal_receiver.aqua
@@ -1,0 +1,87 @@
+class
+   Test_Literal_Receiver
+
+inherit
+   Unit_Test
+
+feature
+
+   Name : String
+      do
+         Result := "test-literal-receiver"
+      end
+
+   Execute
+      local
+         X, R : Integer
+         Flag : Boolean
+      do
+         Success := True
+         X := 5
+
+         --  an integer literal as the receiver of an operator; this used to
+         --  type as ANY, which has no aliased "+"
+         R := 1 + X
+         if R /= 6 then
+            Success := False
+            Fail_Message := "1 + X expected 6, found " & R.To_String
+         end
+
+         R := 0 - X
+         if Success and then R /= -5 then
+            Success := False
+            Fail_Message := "0 - X expected -5, found " & R.To_String
+         end
+
+         --  both operands constant, so the result is folded at compile time
+         R := 10 - 12
+         if Success and then R /= -2 then
+            Success := False
+            Fail_Message := "10 - 12 expected -2, found " & R.To_String
+         end
+
+         --  a negative literal as the receiver: works since #19 folded the
+         --  sign into the literal, but only once the receiver typechecks
+         R := -7 + 10
+         if Success and then R /= 3 then
+            Success := False
+            Fail_Message := "-7 + 10 expected 3, found " & R.To_String
+         end
+
+         --  a literal receiver in a comparison; the context type is BOOLEAN,
+         --  so the literal falls back to INTEGER
+         Flag := 0 < X
+         if Success and then not Flag then
+            Success := False
+            Fail_Message := "0 < X expected true, found false"
+         end
+
+         --  a folded comparison has to be signed, or this reads -7 as a
+         --  large unsigned word and answers false
+         Flag := -7 < 2
+         if Success and then not Flag then
+            Success := False
+            Fail_Message := "-7 < 2 expected true, found false"
+         end
+
+         Flag := 2 < -7
+         if Success and then Flag then
+            Success := False
+            Fail_Message := "2 < -7 expected false, found true"
+         end
+
+         --  division of non-negative constants still folds
+         R := 47 / 5
+         if Success and then R /= 9 then
+            Success := False
+            Fail_Message := "47 / 5 expected 9, found " & R.To_String
+         end
+
+         R := 47 mod 5
+         if Success and then R /= 2 then
+            Success := False
+            Fail_Message := "47 mod 5 expected 2, found " & R.To_String
+         end
+      end
+
+end


### PR DESCRIPTION
An integer literal takes its type from context, but Analyse_Operator analysed the left operand with Type_Any unconditionally.  A literal receiver therefore typed as ANY, which has no aliased "+", so "X + 1" compiled and "1 + X" did not:

  test:81:15: expected type derived from Integral but found Any
  test:81:17: undeclared: +

The workaround was to load the literal into a typed local first, which is why several tests carry a spare Zero.  Since #19 folded a sign into the literal it also blocked "-7 + 10".

Analyse_Operator now hands an integer literal receiver the enclosing Expression_Type when that conforms to Aqua.Integral and is neither deferred nor a generic formal, and Integer otherwise.  A Word_32 destination therefore resolves the operator on Word_32, while a BOOLEAN or ANY context falls back to Integer.  Every other kind of operand still analyses against ANY: string, character and boolean constants already type themselves.

This does not extend to call receivers ("0.Maximum"), which go through Analyse_Precursor, so the Zero locals needed for Zero.Maximum and Zero.To_String stay.

Needs the matching tagatha fix: the aqua backend rejected a constant in receiver position, and constant folding was unsigned.