### PR TITLE
feat: a REAL type in ack and a Real class in the standard library (#8…

### DIFF
--- a/aquarius_ack/src/ack-classes.adb
+++ b/aquarius_ack/src/ack-classes.adb
@@ -504,13 +504,22 @@ package body Ack.Classes is
          for Feature of Layout.Class.Class_Features loop
             if Feature.Is_Property_Of_Class (Layout.Class) then
                Feature.Set_Property_Offset (Offset - Start);
-               Object_Layout.Append
-                 (Layout_Entry'
-                    (No_Name, No_Name, 0, null, null));
-               Put_Log
-                 (Object_Log, Offset,
-                  "prop " & Feature.Declared_Name);
-               Offset := Offset + 1;
+
+               --  One layout entry per machine word: the allocator walks the
+               --  layout initialising a word at a time, so a REAL property
+               --  needs two of them.
+               for Word in 1 .. Value_Words (Feature.Get_Type) loop
+                  Object_Layout.Append
+                    (Layout_Entry'
+                       (No_Name, No_Name, 0, null, null));
+                  Put_Log
+                    (Object_Log, Offset,
+                     "prop " & Feature.Declared_Name
+                     & (if Value_Words (Feature.Get_Type) = 1 then ""
+                        elsif Word = 1 then " (high word)"
+                        else " (low word)"));
+                  Offset := Offset + 1;
+               end loop;
             end if;
          end loop;
 
@@ -876,6 +885,8 @@ package body Ack.Classes is
       procedure Create_Call_Thunk
         (To_Class  : Constant_Class_Entity;
          Link_Name : String;
+         Feature   : not null access constant
+           Ack.Features.Feature_Entity_Record'Class;
          Arg_Count : Tagatha.Argument_Count);
 
       -----------------------
@@ -885,12 +896,45 @@ package body Ack.Classes is
       procedure Create_Call_Thunk
         (To_Class  : Constant_Class_Entity;
          Link_Name : String;
+         Feature   : not null access constant
+           Ack.Features.Feature_Entity_Record'Class;
          Arg_Count : Tagatha.Argument_Count)
       is
          Thunk_Name : constant String :=
                         Class.Link_Name
                         & "$" & Link_Name
                         & "$call_thunk";
+
+         function Thunk_Options return Tagatha.Code.Routine_Options'Class;
+
+         -------------------
+         -- Thunk_Options --
+         -------------------
+
+         function Thunk_Options return Tagatha.Code.Routine_Options'Class is
+            use type Tagatha.Operand_Content;
+            Result : Tagatha.Code.Routine_Options'Class :=
+                       Tagatha.Code.Set_Argument_Count (Arg_Count)
+                         .Set_No_Linkage;
+         begin
+            --  A thunk passes its arguments straight through, but it needs a
+            --  temporary of its own to adjust the object pointer.  The backend
+            --  places that after the declared arguments, so it has to know
+            --  which of them are doubles -- otherwise the temporary lands on
+            --  the second word of a double and destroys a later argument.
+            for Index in 1 .. Feature.Argument_Count loop
+               if Value_Content (Feature.Argument (Index).Get_Type)
+                 = Tagatha.Floating_Point_Content
+               then
+                  Result :=
+                    Result.Set_Argument_Content
+                      (Tagatha.Argument_Index (Index + 1),
+                       Tagatha.Floating_Point_Content);
+               end if;
+            end loop;
+            return Result;
+         end Thunk_Options;
+
       begin
 
          if Thunks.Contains (Thunk_Name) then
@@ -900,10 +944,8 @@ package body Ack.Classes is
          Thunks.Include (Thunk_Name);
 
          Unit.Begin_Routine
-           (Name => Thunk_Name,
-            Options =>
-              Tagatha.Code.Set_Argument_Count (Arg_Count)
-            .Set_No_Linkage);
+           (Name    => Thunk_Name,
+            Options => Thunk_Options);
          Unit.Push_Argument (1);
          Unit.Duplicate;
          Unit.Dereference;
@@ -944,6 +986,7 @@ package body Ack.Classes is
             Create_Call_Thunk
               (Item.Class,
                To_Standard_String (Item.Reference),
+               Item.Feature,
                Tagatha.Argument_Count (Item.Feature.Argument_Count + 1));
          else
             Unit.Data

--- a/aquarius_ack/src/ack-features.adb
+++ b/aquarius_ack/src/ack-features.adb
@@ -10,6 +10,22 @@ with Ack.Semantic.Work;
 
 package body Ack.Features is
 
+   function Call_Result_Content
+     (Feature : Feature_Entity_Record'Class;
+      Current : Ack.Classes.Constant_Class_Entity)
+      return Tagatha.Operand_Content;
+   --  The content of result slot 1.  A routine with a value returns that
+   --  value; a routine of an expanded class with no value still returns one
+   --  result, the updated Current.
+
+   function Local_Content
+     (Feature : Feature_Entity_Record'Class;
+      Index   : Positive)
+      return Tagatha.Operand_Content;
+   --  The content of local slot Index.  Local 1 is Result when the feature has
+   --  one; declared locals follow.  Shelves and the implicit locals introduced
+   --  by attachment tests are always one word.
+
    ------------------
    -- Add_Argument --
    ------------------
@@ -163,6 +179,26 @@ package body Ack.Features is
 
       Feature.Local_Count := Next_Local - 1;
    end Bind;
+
+   -------------------------
+   -- Call_Result_Content --
+   -------------------------
+
+   function Call_Result_Content
+     (Feature : Feature_Entity_Record'Class;
+      Current : Ack.Classes.Constant_Class_Entity)
+      return Tagatha.Operand_Content
+   is
+      use type Ack.Classes.Constant_Class_Entity;
+   begin
+      if Feature.Value_Type /= null then
+         return Value_Content (Feature.Value_Type);
+      elsif Current /= null and then Current.Expanded then
+         return Value_Content (Constant_Entity_Type (Current));
+      else
+         return Tagatha.General_Content;
+      end if;
+   end Call_Result_Content;
 
    ------------------------
    -- Check_Precondition --
@@ -334,6 +370,53 @@ package body Ack.Features is
                            Positive
                              (Get_Program
                                 (Feature.Declaration_Node).Column);
+
+      Current_Content : constant Tagatha.Operand_Content :=
+                          Value_Content (Constant_Entity_Type (Class));
+      --  Argument 1 is Current.  For an expanded class it holds the value
+      --  itself, so for REAL it is a double.
+
+      Result_Content  : constant Tagatha.Operand_Content :=
+                          Call_Result_Content
+                            (Feature.all,
+                             Ack.Classes.Constant_Class_Entity (Class));
+
+      function Frame_Options return Tagatha.Code.Routine_Options'Class;
+
+      -------------------
+      -- Frame_Options --
+      -------------------
+
+      function Frame_Options return Tagatha.Code.Routine_Options'Class is
+         use Tagatha;
+         Result : Tagatha.Code.Routine_Options'Class :=
+                    Tagatha.Code.Default_Options;
+      begin
+         --  Declare every double argument and result, whether or not the
+         --  body reads it: a slot's content fixes its width, and caller and
+         --  callee lay the frame out by a prefix sum over those widths, so
+         --  they have to agree about all of them.
+         if Current_Content = Floating_Point_Content then
+            Result := Result.Set_Argument_Content (1, Floating_Point_Content);
+         end if;
+
+         for Argument of Feature.Arguments loop
+            if Value_Content (Argument.Get_Type) = Floating_Point_Content then
+               Result :=
+                 Result.Set_Argument_Content
+                   (Argument_Index (Argument.Offset), Floating_Point_Content);
+            end if;
+         end loop;
+
+         if Result_Count > 0
+           and then Result_Content = Floating_Point_Content
+         then
+            Result := Result.Set_Result_Content (1, Floating_Point_Content);
+         end if;
+
+         return Result;
+      end Frame_Options;
+
    begin
 
       Unit.Source_Location (Line, Column);
@@ -342,12 +425,12 @@ package body Ack.Features is
          --  Generate a property routine, in case it redefines
          --  an actual routine
 
-         Unit.Begin_Routine (Feature.Link_Name);
+         Unit.Begin_Routine (Feature.Link_Name, Frame_Options);
 
          Unit.Push_Argument (1);
-         Unit.Dereference (Tagatha.General_Content,
+         Unit.Dereference (Value_Content (Feature.Value_Type),
                            Tagatha.Int_32 (Feature.Property_Offset));
-         Unit.Pop_Result (1);
+         Unit.Pop_Result (1, Result_Content);
 
          Unit.Exit_Routine;
          Unit.End_Routine;
@@ -359,7 +442,8 @@ package body Ack.Features is
             --  via a virtual table entry
 
             Unit.Begin_Routine
-              (Name           => Feature.Link_Name);
+              (Name           => Feature.Link_Name,
+               Options        => Frame_Options);
 
             declare
                procedure Push (Index : Positive);
@@ -369,19 +453,25 @@ package body Ack.Features is
                ----------
 
                procedure Push (Index : Positive) is
+                  Content : constant Tagatha.Operand_Content :=
+                              (if Index <= Feature.Arguments.Last_Index
+                               then Value_Content
+                                 (Feature.Arguments.Element (Index).Get_Type)
+                               else Tagatha.General_Content);
                begin
-                  Unit.Push_Argument (Tagatha.Argument_Index (Index + 1));
+                  Unit.Push_Argument
+                    (Tagatha.Argument_Index (Index + 1), Content);
                end Push;
 
             begin
-               Unit.Push_Argument (1);
+               Unit.Push_Argument (1, Current_Content);
                Ack.Generate.Intrinsics.Generate_Intrinsic
                  (Unit, To_Standard_String (Feature.External_Label),
                   Arg_Count, Push'Access);
             end;
 
             if Result_Count > 0 then
-               Unit.Pop_Result (1);
+               Unit.Pop_Result (1, Result_Content);
             end if;
             Unit.Exit_Routine;
             Unit.End_Routine;
@@ -390,7 +480,8 @@ package body Ack.Features is
       elsif Feature.Routine then
 
          Unit.Begin_Routine
-           (Name           => Feature.Link_Name);
+           (Name           => Feature.Link_Name,
+            Options        => Frame_Options);
 
          --  restore Current to our needs
 
@@ -406,8 +497,18 @@ package body Ack.Features is
 --           end if;
 
          for I in 1 .. Feature.Local_Count loop
-            Unit.Push_Constant (Tagatha.Int_32'(0));
-            Unit.Pop_Local (Tagatha.Local_Index (I));
+            declare
+               use type Tagatha.Operand_Content;
+               Content : constant Tagatha.Operand_Content :=
+                           Local_Content (Feature.all, I);
+            begin
+               if Content = Tagatha.Floating_Point_Content then
+                  Unit.Push_Constant (Tagatha.Floating_Point_Constant'(0.0));
+               else
+                  Unit.Push_Constant (Tagatha.Int_32'(0));
+               end if;
+               Unit.Pop_Local (Tagatha.Local_Index (I), Content);
+            end;
          end loop;
 
          if Feature.Declaration_Context.Monitor_Preconditions then
@@ -440,8 +541,9 @@ package body Ack.Features is
                Unit.Push_Name (Once_Flag_Label, Extern => True);
                Unit.Branch (Tagatha.Z, Continue_Once);
                if Feature.Has_Result then
-                  Unit.Push_Name (Once_Value_Label, Extern => True);
-                  Unit.Pop_Result (1);
+                  Unit.Push_Name (Once_Value_Label, Extern => True,
+                                  Content => Result_Content);
+                  Unit.Pop_Result (1, Result_Content);
                end if;
                Unit.Exit_Routine;
                Unit.Set_Label (Continue_Once);
@@ -488,12 +590,13 @@ package body Ack.Features is
             if Feature.Once then
                Unit.Push_Constant (Tagatha.Int_32'(1));
                Unit.Pop_Name (Once_Flag_Label, Extern => True);
-               Unit.Push_Local (1);
-               Unit.Pop_Name (Once_Value_Label, Extern => True);
+               Unit.Push_Local (1, Result_Content);
+               Unit.Pop_Name (Once_Value_Label, Extern => True,
+                              Content => Result_Content);
             end if;
 
-            Unit.Push_Local (1);
-            Unit.Pop_Result (1);
+            Unit.Push_Local (1, Result_Content);
+            Unit.Pop_Result (1, Result_Content);
          end if;
 
          Unit.Exit_Routine;
@@ -561,6 +664,29 @@ package body Ack.Features is
 
    end Instantiate;
 
+   -------------------
+   -- Local_Content --
+   -------------------
+
+   function Local_Content
+     (Feature : Feature_Entity_Record'Class;
+      Index   : Positive)
+      return Tagatha.Operand_Content
+   is
+   begin
+      if Feature.Has_Result and then Index = 1 then
+         return Value_Content (Feature.Value_Type);
+      end if;
+
+      for Local of Feature.Locals loop
+         if Local.Offset = Index then
+            return Value_Content (Local.Get_Type);
+         end if;
+      end loop;
+
+      return Tagatha.General_Content;
+   end Local_Content;
+
    --------------------------
    -- Is_Property_Of_Class --
    --------------------------
@@ -627,7 +753,8 @@ package body Ack.Features is
 --           & (if Feature.Active_Class.Expanded then "yes" else "no"));
 
       if Feature.Active_Class.Expanded then
-         Unit.Pop_Argument (1);
+         Unit.Pop_Argument
+           (1, Value_Content (Constant_Entity_Type (Feature.Active_Class)));
       else
          if Feature.Get_Type.Proper_Ancestor_Of (Value_Type) then
             Unit.Duplicate;
@@ -670,7 +797,7 @@ package body Ack.Features is
             Unit.Operate (Tagatha.Op_Add);
          end if;
 
-         Unit.Pop_Indirect (Tagatha.General_Content,
+         Unit.Pop_Indirect (Value_Content (Feature.Value_Type),
                             Tagatha.Int_32 (Feature.Property_Offset));
       end if;
    end Pop_Entity;
@@ -712,6 +839,11 @@ package body Ack.Features is
    is
       Current        : constant Ack.Classes.Constant_Class_Entity :=
                          Ack.Classes.Constant_Class_Entity (Context);
+      Result_Content : constant Tagatha.Operand_Content :=
+                         Call_Result_Content (Feature, Current);
+      Returns        : constant Tagatha.Return_Content_Array :=
+                         [1 => Result_Content,
+                          others => Tagatha.General_Content];
    begin
 
       if Feature.Standard_Name = "void" then
@@ -735,8 +867,17 @@ package body Ack.Features is
                     (Tagatha.Int_32'
                        (Character'Pos (Text (Text'First))));
                when N_Integer_Constant =>
+                  if Is_Floating_Point (Feature.Value_Type) then
+                     --  an integer literal declared as a REAL value
+                     Unit.Push_Constant
+                       (Tagatha.Floating_Point_Constant'Value (Text));
+                  else
+                     Unit.Push_Constant
+                       (Tagatha.Int_32'Value (Text));
+                  end if;
+               when N_Real_Constant =>
                   Unit.Push_Constant
-                    (Tagatha.Int_32'Value (Text));
+                    (Tagatha.Floating_Point_Constant'Value (Text));
                when N_Boolean_Constant =>
                   Unit.Push_Constant
                     (Tagatha.Int_32'
@@ -748,7 +889,8 @@ package body Ack.Features is
       end if;
 
       if not Have_Current then
-         Unit.Push_Argument (1);
+         Unit.Push_Argument
+           (1, Value_Content (Constant_Entity_Type (Current)));
       end if;
 
 --        if Feature.Definition_Class /= Current
@@ -788,13 +930,14 @@ package body Ack.Features is
             end if;
             Push_Offset (Unit, Feature.Property_Offset);
             Unit.Operate (Tagatha.Op_Add);
-            Unit.Dereference;
+            Unit.Dereference (Value_Content (Feature.Value_Type), 0);
          end if;
       else
          if Current.Expanded then
             Unit.Call (Feature.Link_Name,
                        Feature.Argument_Count + 1,
-                       1);
+                       1,
+                       Returns => Returns);
          else
             --  push feature address from virtual table
 
@@ -834,7 +977,8 @@ package body Ack.Features is
             begin
                Unit.Set_Label (L);
                Unit.Indirect_Call
-                 (Feature.Argument_Count + 1, 1);
+                 (Feature.Argument_Count + 1, 1,
+                  Returns => Returns);
             end;
          end if;
 
@@ -860,7 +1004,7 @@ package body Ack.Features is
             --
             --  push result
             if Feature.Has_Result then
-               Unit.Push_Return (1);
+               Unit.Push_Return (1, Result_Content);
             end if;
          end if;
       end if;
@@ -888,7 +1032,8 @@ package body Ack.Features is
       end if;
 
       if not Have_Current then
-         Unit.Push_Argument (1);
+         Unit.Push_Argument
+           (1, Value_Content (Constant_Entity_Type (Current)));
       end if;
 
       if Feature.Intrinsic then

--- a/aquarius_ack/src/ack-generate-primitives.adb
+++ b/aquarius_ack/src/ack-generate-primitives.adb
@@ -49,6 +49,23 @@ package body Ack.Generate.Primitives is
    procedure Generate_Mod (Unit : in out Tagatha.Code.Instance'Class);
    procedure Generate_Join (Unit : in out Tagatha.Code.Instance'Class);
 
+   --  Floating point arithmetic has its own operators in the Tagatha IR, so
+   --  REAL cannot share the integer intrinsics; it names these instead.  The
+   --  comparisons and Op_Mod are not duplicated, because the Aqua backend
+   --  already picks fcmp/feql/frem from the operand content.
+   procedure Generate_Fadd (Unit : in out Tagatha.Code.Instance'Class);
+   procedure Generate_Fsub (Unit : in out Tagatha.Code.Instance'Class);
+   procedure Generate_Fmul (Unit : in out Tagatha.Code.Instance'Class);
+   procedure Generate_Fdiv (Unit : in out Tagatha.Code.Instance'Class);
+
+   procedure Generate_Intrinsic_Real_Zero
+     (Unit : in out Tagatha.Code.Instance'Class);
+   procedure Generate_Intrinsic_Real_One
+     (Unit : in out Tagatha.Code.Instance'Class);
+
+   procedure Generate_To_Real (Unit : in out Tagatha.Code.Instance'Class);
+   procedure Generate_To_Integer (Unit : in out Tagatha.Code.Instance'Class);
+
    procedure Generate_Offset_Words (Unit : in out Tagatha.Code.Instance'Class);
 
    procedure Generate_Intrinsic_Nop
@@ -197,6 +214,16 @@ package body Ack.Generate.Primitives is
 
       Add ("zero", Generate_Intrinsic_Zero'Access);
       Add ("one", Generate_Intrinsic_One'Access);
+
+      Add ("real_zero", Generate_Intrinsic_Real_Zero'Access);
+      Add ("real_one", Generate_Intrinsic_Real_One'Access);
+      Add ("fadd", Generate_Fadd'Access);
+      Add ("fsubtract", Generate_Fsub'Access);
+      Add ("fmultiply", Generate_Fmul'Access);
+      Add ("fdivide", Generate_Fdiv'Access);
+      Add ("to_real", Generate_To_Real'Access);
+      Add ("to_integer", Generate_To_Integer'Access);
+
       Add ("add", Generate_Add'Access);
       Add ("subtract", Generate_Subtract'Access);
       Add ("negate", Generate_Negate'Access);
@@ -245,6 +272,42 @@ package body Ack.Generate.Primitives is
    begin
       Unit.Operate (Tagatha.Op_Divide);
    end Generate_Divide;
+
+   -------------------
+   -- Generate_Fadd --
+   -------------------
+
+   procedure Generate_Fadd (Unit : in out Tagatha.Code.Instance'Class) is
+   begin
+      Unit.Operate (Tagatha.Op_Fadd);
+   end Generate_Fadd;
+
+   -------------------
+   -- Generate_Fdiv --
+   -------------------
+
+   procedure Generate_Fdiv (Unit : in out Tagatha.Code.Instance'Class) is
+   begin
+      Unit.Operate (Tagatha.Op_Fdiv);
+   end Generate_Fdiv;
+
+   -------------------
+   -- Generate_Fmul --
+   -------------------
+
+   procedure Generate_Fmul (Unit : in out Tagatha.Code.Instance'Class) is
+   begin
+      Unit.Operate (Tagatha.Op_Fmul);
+   end Generate_Fmul;
+
+   -------------------
+   -- Generate_Fsub --
+   -------------------
+
+   procedure Generate_Fsub (Unit : in out Tagatha.Code.Instance'Class) is
+   begin
+      Unit.Operate (Tagatha.Op_Fsub);
+   end Generate_Fsub;
 
    --------------------
    -- Generate_Equal --
@@ -361,6 +424,30 @@ package body Ack.Generate.Primitives is
       Unit.Swap;
       Unit.Pop;
    end Generate_Intrinsic_Replace_Current;
+
+   ----------------------------------
+   -- Generate_Intrinsic_Real_One --
+   ----------------------------------
+
+   procedure Generate_Intrinsic_Real_One
+     (Unit : in out Tagatha.Code.Instance'Class)
+   is
+   begin
+      Unit.Drop;
+      Unit.Push_Constant (Tagatha.Floating_Point_Constant'(1.0));
+   end Generate_Intrinsic_Real_One;
+
+   ----------------------------------
+   -- Generate_Intrinsic_Real_Zero --
+   ----------------------------------
+
+   procedure Generate_Intrinsic_Real_Zero
+     (Unit : in out Tagatha.Code.Instance'Class)
+   is
+   begin
+      Unit.Drop;
+      Unit.Push_Constant (Tagatha.Floating_Point_Constant'(0.0));
+   end Generate_Intrinsic_Real_Zero;
 
    -----------------------------
    -- Generate_Intrinsic_Zero --
@@ -508,6 +595,36 @@ package body Ack.Generate.Primitives is
    begin
       Unit.Operate (Tagatha.Op_Subtract);
    end Generate_Subtract;
+
+   -------------------------
+   -- Generate_To_Integer --
+   -------------------------
+
+   procedure Generate_To_Integer
+     (Unit : in out Tagatha.Code.Instance'Class)
+   is
+   begin
+      --  Current is the only operand, and it is the double to convert.
+      --  Rounds to nearest: the VM's fix has no other rounding mode, so
+      --  truncation towards zero is synthesised in REAL itself.
+      Unit.Convert (Tagatha.General_Content);
+   end Generate_To_Integer;
+
+   ----------------------
+   -- Generate_To_Real --
+   ----------------------
+
+   procedure Generate_To_Real
+     (Unit : in out Tagatha.Code.Instance'Class)
+   is
+   begin
+      --  Stack is Current then the integer argument.  Convert the argument
+      --  into a double of its own before the move, so that this does not
+      --  depend on Current being an operand the backend can flot into.
+      Unit.Convert (Tagatha.Floating_Point_Content);
+      Unit.Swap;
+      Unit.Pop;
+   end Generate_To_Real;
 
    ------------------
    -- Generate_Xor --

--- a/aquarius_ack/src/ack-generate.adb
+++ b/aquarius_ack/src/ack-generate.adb
@@ -531,7 +531,12 @@ package body Ack.Generate is
                         Text : constant String :=
                                  To_String (Get_Name (Value));
                      begin
-                        if Text (Text'First) = '-' then
+                        if Is_Floating_Point (Get_Type (Expression)) then
+                           --  an integer literal in a real context is a real
+                           --  literal written without a fraction
+                           Unit.Push_Constant
+                             (Tagatha.Floating_Point_Constant'Value (Text));
+                        elsif Text (Text'First) = '-' then
                            --  the target word is 32 bits wide, so push the
                            --  two's complement pattern rather than a
                            --  64 bit sign extension
@@ -543,6 +548,10 @@ package body Ack.Generate is
                              (Tagatha.Word_64'Value (Text));
                         end if;
                      end;
+                  when N_Real_Constant =>
+                     Unit.Push_Constant
+                       (Tagatha.Floating_Point_Constant'Value
+                          (To_String (Get_Name (Value))));
                   when N_Boolean_Constant =>
                      Unit.Push_Constant
                        (Tagatha.Int_32'

--- a/aquarius_ack/src/ack-parser-expressions.adb
+++ b/aquarius_ack/src/ack-parser-expressions.adb
@@ -23,11 +23,11 @@ package body Ack.Parser.Expressions is
      (From : Aquarius.Programs.Program_Tree)
       return Node_Id;
 
-   function Signed_Integer_Constant
+   function Signed_Numeric_Constant
      (Node     : Node_Id;
       Negative : Boolean)
       return Node_Id;
-   --  If Node is an integer manifest constant, return an equivalent
+   --  If Node is an integer or real manifest constant, return an equivalent
    --  constant node with Negative applied to its literal text.  Otherwise
    --  return No_Node.
 
@@ -81,12 +81,12 @@ package body Ack.Parser.Expressions is
             Operator : constant String := Prefix.Concatenate_Children;
             Folded   : constant Node_Id :=
                          (if Operator = "-" or else Operator = "+"
-                          then Signed_Integer_Constant
+                          then Signed_Numeric_Constant
                             (Node, Negative => Operator = "-")
                           else No_Node);
          begin
             if Folded /= No_Node then
-               --  a signed integer literal; no operator call required
+               --  a signed numeric literal; no operator call required
                Node := Folded;
             else
                Node := New_Node (N_Operator, Prefix,
@@ -238,6 +238,9 @@ package body Ack.Parser.Expressions is
       elsif Choice.Name = "integer_constant" then
          Kind := N_Integer_Constant;
          Name := Get_Name_Id (Choice.Concatenate_Children);
+      elsif Choice.Name = "real_constant" then
+         Kind := N_Real_Constant;
+         Name := Get_Name_Id (Choice.Concatenate_Children);
       elsif Choice.Name = "boolean_constant" then
          Kind := N_Boolean_Constant;
          Name := Get_Name_Id (Choice.Concatenate_Children);
@@ -343,10 +346,10 @@ package body Ack.Parser.Expressions is
    end Import_Primary;
 
    -----------------------------
-   -- Signed_Integer_Constant --
+   -- Signed_Numeric_Constant --
    -----------------------------
 
-   function Signed_Integer_Constant
+   function Signed_Numeric_Constant
      (Node     : Node_Id;
       Negative : Boolean)
       return Node_Id
@@ -359,7 +362,7 @@ package body Ack.Parser.Expressions is
       declare
          Value : constant Node_Id := Constant_Value (Node);
       begin
-         if Kind (Value) /= N_Integer_Constant then
+         if Kind (Value) not in N_Integer_Constant | N_Real_Constant then
             return No_Node;
          end if;
 
@@ -379,10 +382,10 @@ package body Ack.Parser.Expressions is
               (N_Constant, Get_Program (Node),
                Field_2 =>
                  New_Node
-                   (N_Integer_Constant, Get_Program (Value),
+                   (Kind (Value), Get_Program (Value),
                     Name => Get_Name_Id (Image)));
          end;
       end;
-   end Signed_Integer_Constant;
+   end Signed_Numeric_Constant;
 
 end Ack.Parser.Expressions;

--- a/aquarius_ack/src/ack-semantic-analysis-classes.adb
+++ b/aquarius_ack/src/ack-semantic-analysis-classes.adb
@@ -526,6 +526,9 @@ package body Ack.Semantic.Analysis.Classes is
                              Integer'Value (To_String (Get_Name (Value)));
                         end if;
 
+                     when N_Real_Constant =>
+                        Add_Note_Text (To_String (Get_Name (Value)));
+
                      when N_Boolean_Constant =>
                         Add_Note_Text (if Boolean_Value (Value)
                                        then "True" else "False");

--- a/aquarius_ack/src/ack-semantic-analysis-expressions.adb
+++ b/aquarius_ack/src/ack-semantic-analysis-expressions.adb
@@ -126,13 +126,22 @@ package body Ack.Semantic.Analysis.Expressions is
                                      Types.Type_Character,
                                   when N_Integer_Constant =>
                                      Types.Type_Integral (Value),
+                                  when N_Real_Constant =>
+                                     Types.Type_Real,
                                   when N_Boolean_Constant =>
                                      Types.Type_Boolean);
             begin
                if Kind (Value) = N_Integer_Constant then
                   Set_Type (Expression, Expression_Type);
                   Set_Entity (Expression, Expression_Type);
-                  if not Expression_Type.Conforms_To (Value_Type) then
+                  --  An integer literal takes the type of its context, which
+                  --  has to be an integral type -- or REAL, in which case the
+                  --  literal is a real literal written without a fraction.
+                  --  Anything wider than a literal needs an explicit
+                  --  conversion; there is no integer to real promotion.
+                  if not Expression_Type.Conforms_To (Value_Type)
+                    and then not Is_Floating_Point (Expression_Type)
+                  then
                      Error (Expression, E_Type_Error, Value_Type);
                   end if;
                else
@@ -180,9 +189,13 @@ package body Ack.Semantic.Analysis.Expressions is
          if Value = No_Node
            or else Kind (Value) /= N_Integer_Constant
          then
-            --  string, character and boolean constants type themselves, and
-            --  any other expression carries its own type, so ANY is enough
+            --  string, character, real and boolean constants type themselves,
+            --  and any other expression carries its own type, so ANY is enough
             return Types.Type_Any;
+         elsif Is_Floating_Point (Expression_Type) then
+            --  an integer literal in a real context is a real literal, so the
+            --  operator has to be resolved on REAL
+            return Types.Type_Real;
          elsif Expression_Type /= null
            and then Expression_Type.Conforms_To (Types.Type_Integral (Left))
            and then not Expression_Type.Deferred

--- a/aquarius_ack/src/ack-semantic-types.adb
+++ b/aquarius_ack/src/ack-semantic-types.adb
@@ -21,6 +21,9 @@ package body Ack.Semantic.Types is
    function Type_Integer return Ack.Types.Type_Entity
    is (Get_Top_Level_Type ("integer"));
 
+   function Type_Real return Ack.Types.Type_Entity
+   is (Get_Top_Level_Type ("real"));
+
    function Type_String return Ack.Types.Type_Entity
    is (Get_Top_Level_Type ("string"));
 

--- a/aquarius_ack/src/ack-semantic-types.ads
+++ b/aquarius_ack/src/ack-semantic-types.ads
@@ -8,6 +8,8 @@ private package Ack.Semantic.Types is
 
    function Type_Integer return Ack.Types.Type_Entity;
 
+   function Type_Real return Ack.Types.Type_Entity;
+
    function Type_String return Ack.Types.Type_Entity;
 
    function Type_Character return Ack.Types.Type_Entity;

--- a/aquarius_ack/src/ack-variables.adb
+++ b/aquarius_ack/src/ack-variables.adb
@@ -122,9 +122,11 @@ package body Ack.Variables is
 
       case Variable.Kind is
          when Local =>
-            Unit.Pop_Local (Tagatha.Local_Index (Variable.Offset));
+            Unit.Pop_Local (Tagatha.Local_Index (Variable.Offset),
+                            Value_Content (Variable.Get_Type));
          when Argument =>
-            Unit.Pop_Argument (Tagatha.Argument_Index (Variable.Offset));
+            Unit.Pop_Argument (Tagatha.Argument_Index (Variable.Offset),
+                               Value_Content (Variable.Get_Type));
       end case;
    end Pop_Entity;
 
@@ -143,15 +145,29 @@ package body Ack.Variables is
    begin
       case Variable.Kind is
          when Local =>
-            Unit.Push_Local (Tagatha.Local_Index (Variable.Offset));
+            --  An iteration variable's type is the element type, but its slot
+            --  holds the cursor -- always a reference -- and the element
+            --  comes from the call below.  Reading the slot as the element
+            --  type would read a second word that was never written.
+            Unit.Push_Local
+              (Tagatha.Local_Index (Variable.Offset),
+               (if Variable.Iterator
+                then Tagatha.General_Content
+                else Value_Content (Variable.Get_Type)));
 
             if Variable.Iterator then
                declare
+                  Cursor_Type : constant Ack.Types.Type_Entity :=
+                                  Ack.Types.Type_Entity (Variable.Iteration);
                   Class : constant Ack.Classes.Class_Entity :=
-                            Ack.Types.Type_Entity
-                              (Variable.Iteration).Class;
+                            Cursor_Type.Class;
+                  --  Look the feature up on the type, not the class: only the
+                  --  type carries the generic bindings, so only it yields an
+                  --  Element whose result type is the actual element type.
+                  --  The class's version still returns the formal, which is
+                  --  one word wide whatever the actual turns out to be.
                   Feature : constant Ack.Features.Feature_Entity :=
-                              Class.Feature
+                              Cursor_Type.Feature
                                 (Get_Name_Id ("element"));
                begin
                   Feature.Push_Entity
@@ -162,7 +178,8 @@ package body Ack.Variables is
             end if;
 
          when Argument =>
-            Unit.Push_Argument (Tagatha.Argument_Index (Variable.Offset));
+            Unit.Push_Argument (Tagatha.Argument_Index (Variable.Offset),
+                                Value_Content (Variable.Get_Type));
       end case;
    end Push_Entity;
 

--- a/aquarius_ack/src/ack-variables.ads
+++ b/aquarius_ack/src/ack-variables.ads
@@ -17,6 +17,12 @@ package Ack.Variables is
      (Variable : in out Variable_Entity_Record'Class;
       Offset   : Positive);
 
+   function Offset
+     (Variable : Variable_Entity_Record'Class)
+      return Positive;
+   --  The variable's frame slot index: an argument index for an argument, a
+   --  local index for a local
+
    type Variable_Entity is access all Variable_Entity_Record'Class;
 
    function New_Argument_Entity
@@ -102,5 +108,10 @@ private
      (Entity : not null access Root_Entity_Type'Class)
       return Boolean
    is (Entity.all in Variable_Entity_Record'Class);
+
+   function Offset
+     (Variable : Variable_Entity_Record'Class)
+      return Positive
+   is (Variable.Offset);
 
 end Ack.Variables;

--- a/aquarius_ack/src/ack.ads
+++ b/aquarius_ack/src/ack.ads
@@ -89,6 +89,7 @@ package Ack is
       N_String_Constant,
       N_Character_Constant,
       N_Integer_Constant,
+      N_Real_Constant,
       N_Boolean_Constant,
       N_Variable,
       N_Precursor_Element,
@@ -327,6 +328,38 @@ package Ack is
      (Entity : not null access Root_Entity_Type)
       return Entity_Type
    is (Entity_Type (Entity));
+
+   Real_Class_Link_Name : constant String := "real";
+   --  The one class whose values are IEEE-754 binary64.  There is no
+   --  descendant to worry about: REAL is expanded, so it cannot be inherited
+   --  from, and a nested class of the same name has a qualified link name.
+
+   function Is_Floating_Point
+     (Entity : access constant Root_Entity_Type'Class)
+      return Boolean
+   is (Entity /= null
+       and then Entity.Class_Context /= null
+       and then Entity.Class_Context.Link_Name = Real_Class_Link_Name);
+   --  True for REAL itself and for any type whose class is REAL.  Anything
+   --  typed by this needs a two-word frame slot and floating point opcodes.
+
+   function Value_Content
+     (Entity : access constant Root_Entity_Type'Class)
+      return Tagatha.Operand_Content
+   is (if Is_Floating_Point (Entity)
+       then Tagatha.Floating_Point_Content
+       else Tagatha.General_Content);
+   --  The Tagatha content of a value of this type.  Every push, pop and
+   --  dereference of a value has to carry it: the content fixes the operand
+   --  width, so a double read or written as General_Content silently loses
+   --  its low word.
+
+   function Value_Words
+     (Entity : access constant Root_Entity_Type'Class)
+      return Word_Offset
+   is (if Is_Floating_Point (Entity) then 2 else 1);
+   --  How many machine words a value of this type occupies in an object
+   --  record.
 
    function Expanded
      (Entity : Root_Entity_Type)
@@ -572,7 +605,7 @@ package Ack is
 
    function Has_Name (N : Node_Id) return Boolean
    is (Kind (N) in N_Identifier | N_Feature_Name | N_Feature_Alias
-         | N_Variable | N_Integer_Constant
+         | N_Variable | N_Integer_Constant | N_Real_Constant
          | N_Boolean_Constant | N_Character_Constant
          | N_Effective_Routine | N_Precursor_Element
          | N_Explicit_Creation_Call

--- a/aquarius_programs/src/aquarius-grammars-builtin.adb
+++ b/aquarius_programs/src/aquarius-grammars-builtin.adb
@@ -8,6 +8,8 @@ package body Aquarius.Grammars.Builtin is
 
    Ada_Identifiers        : Lexer;
    Ada_Numeric_Literals   : Lexer;
+   Ada_Integer_Literals   : Lexer;
+   Ada_Real_Literals      : Lexer;
    Ada_Character_Literals : Lexer;
    Ada_String_Literals    : Lexer;
    Ada_Comments           : Lexer;
@@ -48,6 +50,19 @@ package body Aquarius.Grammars.Builtin is
         Numeral & Literal ('#') & Based_Numeral &
         Optional (Literal ('.') & Based_Numeral) &
         Literal ('#') & Optional (Exponent);
+      --  A grammar that has a separate real token cannot use
+      --  ada_numeric_literal for its integers: both would match "3.14", and
+      --  the tokeniser hands an equal-length tie to the parser to resolve,
+      --  which silently picks whichever the context allows first.  These two
+      --  split the same syntax on the decimal point instead.  A based
+      --  literal is always an integer here; a based real (16#F.8#) is not
+      --  accepted by either.
+      Integer_Only_Literal : constant Lexer :=
+        (Numeral & Literal ('#') & Based_Numeral & Literal ('#')
+         & Optional (Exponent))
+        or (Numeral & Optional (Exponent));
+      Real_Only_Literal : constant Lexer :=
+        Numeral & Literal ('.') & Numeral & Optional (Exponent);
       String_Element : constant Lexer :=
         (Literal ('"') & Literal ('"')) or (not Literal ('"'));
       Backslash_Escaped_String_Element : constant Lexer :=
@@ -69,6 +84,8 @@ package body Aquarius.Grammars.Builtin is
         Optional (Repeat (Identifier_Start or Identifier_Extend));
       Ada_Numeric_Literals :=
         Based_Literal or Decimal_Literal;
+      Ada_Integer_Literals := Integer_Only_Literal;
+      Ada_Real_Literals    := Real_Only_Literal;
 
       Ada_Character_Literals :=
         Literal (''') & Graphic & Literal (''');
@@ -129,6 +146,10 @@ package body Aquarius.Grammars.Builtin is
          return Ada_Character_Literals;
       elsif Name = "ada_numeric_literal" then
          return Ada_Numeric_Literals;
+      elsif Name = "ada_integer_literal" then
+         return Ada_Integer_Literals;
+      elsif Name = "ada_real_literal" then
+         return Ada_Real_Literals;
       elsif Name = "ada_delimiters" then
          return Ada_Delimiters;
       elsif Name = "ada_symbol" then

--- a/docs/ebnf-grammar-syntax.md
+++ b/docs/ebnf-grammar-syntax.md
@@ -69,8 +69,16 @@ delimiter  ::= .delimiters "{},=:"           -- each char is its own token
 Three token-body forms:
 
 - **`.standard <name>`** — a built-in lexer. Available:
-  `ada_identifier`, `ada_numeric_literal`, `ada_character_literal`,
-  `ada_string_literal`, `ada_symbol`, `ada_comment`.
+  `ada_identifier`, `ada_numeric_literal`, `ada_integer_literal`,
+  `ada_real_literal`, `ada_character_literal`, `ada_string_literal`,
+  `ada_symbol`, `ada_comment`.
+
+  `ada_numeric_literal` covers both integers and reals, so a grammar with a
+  *separate* real token must use `ada_integer_literal` (no decimal point;
+  based literals like `16#ff#` are integers) and `ada_real_literal`
+  (`digits . digits` with an optional exponent) instead — otherwise both
+  token classes match `3.14` with the same length and the tie is resolved by
+  whichever the parse context happens to accept.
 - **`.delimiters "<chars>"`** — declares each character in the string as a
   single-character delimiter token.
 - **regex** (`!...!`) — see below.

--- a/share/aquarius/grammar/aqua/aqua.ebnf
+++ b/share/aquarius/grammar/aqua/aqua.ebnf
@@ -2,8 +2,8 @@ top_level ::= class_declaration
 case_sensitive = false
 
 identifier         ::= !\l[\w]*!
-integer            ::= .standard ada_numeric_literal
-real               ::= ![0-9]+\.[0-9]+([eE][0-9]+)?!
+real               ::= .standard ada_real_literal
+integer            ::= .standard ada_integer_literal
 character_constant ::= !\'[.]\'!
 string_constant     ::= .standard ada_string_literal
 

--- a/share/aquarius/lib/aqua/standard/real.aqua
+++ b/share/aquarius/lib/aqua/standard/real.aqua
@@ -1,0 +1,223 @@
+expanded class
+   Real
+
+inherit
+   Aqua.Algebra.Additive redefine Subtract, Negate, Equal end
+   Aqua.Algebra.Multiplicative redefine Equal end
+   Aqua.Comparable redefine Equal end
+
+feature
+
+   --  IEEE-754 binary64.  A Real occupies two machine words, and the compiler
+   --  marks every push, pop and frame slot that holds one, so the class needs
+   --  no storage of its own beyond the single frame slot declared above.
+
+   Add      (Right : Real) : Real external "intrinsic" alias "fadd"
+   Subtract (Right : Real) : Real external "intrinsic" alias "fsubtract"
+   Multiply (Right : Real) : Real external "intrinsic" alias "fmultiply"
+   Divide   (Right : Real) : Real external "intrinsic" alias "fdivide"
+
+   --  IEEE remainder, from the VM's frem opcode
+   Modulus  (Right : Real) : Real external "intrinsic"
+
+   Negate : Real external "intrinsic"
+
+   Zero : Real external "intrinsic" alias "real_zero"
+   One  : Real external "intrinsic" alias "real_one"
+
+   --  Comparison is ordered-only: the VM's fcmp reports an unordered pair as
+   --  equal, so <, <=, > and >= are meaningless if either operand is NaN.
+   --  Equality uses feql, which does report NaN /= NaN correctly.
+   Equal (Right : Real) : Boolean external "intrinsic"
+
+   GE (Right : Real) : Boolean external "intrinsic"
+   LE (Right : Real) : Boolean external "intrinsic"
+   GT (Right : Real) : Boolean external "intrinsic"
+   LT (Right : Real) : Boolean external "intrinsic"
+
+feature  --  conversions
+
+   Convert_From (Other : Integer) external "intrinsic" alias "to_real"
+      --  Replace Current with Other converted to a double
+
+   Rounded : Integer external "intrinsic" alias "to_integer"
+      --  Nearest integer; the VM's fix has no other rounding mode
+
+   Floor : Integer
+         --  Largest integer that is not greater than Current, built from
+         --  Rounded because there is no floor opcode
+      local
+         N : Integer
+         R : Real
+      do
+         N := Rounded
+         R.Convert_From (N)
+         if R > Current then
+            N := N - 1
+         end
+         Result := N
+      end
+
+   Ceiling : Integer
+      local
+         N : Integer
+         R : Real
+      do
+         N := Rounded
+         R.Convert_From (N)
+         if R < Current then
+            N := N + 1
+         end
+         Result := N
+      end
+
+   Truncated : Integer
+         --  Towards zero, which is neither of the two roundings the VM has
+      local
+         Zero_Value : Real
+      do
+         if Current < Zero_Value then
+            Result := Ceiling
+         else
+            Result := Floor
+         end
+      end
+
+   Absolute_Value : Real
+      local
+         Value      : Real
+         Zero_Value : Real
+      do
+         Value := Current
+         if Value < Zero_Value then
+            Result := -Value
+         else
+            Result := Value
+         end
+      end
+
+feature  --  output
+
+   To_String : String
+         --  Up to six decimal places, with trailing zeros dropped but always
+         --  at least one digit after the point.  A magnitude the fixed form
+         --  cannot show -- one whose whole part would not fit in an Integer,
+         --  or one so small that six places would all be zero -- is
+         --  normalised to a mantissa in [1, 10) and an exponent, which
+         --  String.To_Real reads back.
+      local
+         Value      : Real
+         Ten        : Real
+         One_Value  : Real
+         Upper      : Real
+         Lower      : Real
+         Zero_Value : Real
+         Exponent   : Integer
+         Negative   : Boolean
+      do
+         Value := Current
+         Negative := false
+         if Value < Zero_Value then
+            Value := -Value
+            Negative := true
+         end
+
+         Ten.Convert_From (10)
+         One_Value.Convert_From (1)
+         Upper.Convert_From (1000000000)
+         Exponent := 0
+
+         --  1.0e-4 is the smallest magnitude the fixed form still shows to
+         --  four significant places
+         Lower.Convert_From (10000)
+         Lower := One_Value / Lower
+
+         if Value > Zero_Value
+           and then (Value >= Upper or else Value < Lower)
+         then
+            from
+               Exponent := 0
+            until
+               Value < Ten
+            loop
+               Value := Value / Ten
+               Exponent := Exponent + 1
+            end
+
+            from
+               Exponent := Exponent
+            until
+               Value >= One_Value
+            loop
+               Value := Value * Ten
+               Exponent := Exponent - 1
+            end
+         end
+
+         Result := Fixed_Image (Value)
+
+         if Exponent /= 0 then
+            Result := Result & "e" & Exponent.To_String
+         end
+
+         if Negative then
+            Result := "-" & Result
+         end
+      end
+
+feature { None }
+
+   Fixed_Image (Value : Real) : String
+         --  Value must not be negative and its whole part must fit in an
+         --  Integer; To_String normalises anything else first
+      local
+         Fraction   : Real
+         Scaled     : Real
+         Scale      : Real
+         Whole_Real : Real
+         Whole      : Integer
+         Places     : Integer
+         Index      : Integer
+         Fraction_Image : String
+      do
+         Whole := Value.Truncated
+         Whole_Real.Convert_From (Whole)
+         Fraction := Value - Whole_Real
+
+         Scale.Convert_From (1000000)
+         Scaled := Fraction * Scale
+         Places := Scaled.Rounded
+
+         --  rounding the sixth place can carry into the whole part
+         if Places >= 1000000 then
+            Places := Places - 1000000
+            Whole := Whole + 1
+         end
+
+         Fraction_Image := Places.To_String
+
+         from
+            Index := Fraction_Image.Length
+         until
+            Index >= 6
+         loop
+            Fraction_Image := "0" & Fraction_Image
+            Index := Index + 1
+         end
+
+         from
+            Index := 6
+         until
+            Index = 1 or else Fraction_Image.Element (Index) /= '0'
+         loop
+            Index := Index - 1
+         end
+
+         Fraction_Image := Fraction_Image.Slice (1, Index)
+
+         Result := Whole.To_String & "." & Fraction_Image
+      end
+
+   Internal : System.Internal_Frame_Word
+
+end

--- a/share/aquarius/lib/aqua/standard/string.aqua
+++ b/share/aquarius/lib/aqua/standard/string.aqua
@@ -128,6 +128,90 @@ feature
          end         
       end
 
+   To_Real : Real
+         --  Reads [sign] digits [. digits] [e [sign] digits].  Underscores
+         --  are ignored, as in an Aqua literal.  A malformed string is not
+         --  diagnosed: characters that are not part of the grammar above are
+         --  read as digits, so the result is meaningless rather than an error.
+      local
+         Index        : Integer
+         Ch           : Character
+         Code         : Integer
+         Digit_Value  : Integer
+         Digit        : Real
+         Ten          : Real
+         Scale        : Real
+         Exponent     : Integer
+         Negative     : Boolean
+         Exp_Negative : Boolean
+         In_Fraction  : Boolean
+         In_Exponent  : Boolean
+      do
+         Ten.Convert_From (10)
+         Scale.Convert_From (1)
+         Exponent := 0
+         Negative := false
+         Exp_Negative := false
+         In_Fraction := false
+         In_Exponent := false
+
+         from
+            Index := 1
+         until
+            Index > Length
+         loop
+            Ch := Current.Element (Index)
+            if Ch = '-' then
+               if In_Exponent then
+                  Exp_Negative := true
+               else
+                  Negative := true
+               end
+            elsif Ch = '+' then
+               --  ignore
+            elsif Ch = '_' then
+               --  ignore
+            elsif Ch = '.' then
+               In_Fraction := true
+            elsif Ch = 'e' or else Ch = 'E' then
+               In_Exponent := true
+            else
+               Code.Convert_From (Ch.UTF_32_Code)
+               Digit_Value := Code - 48
+               if In_Exponent then
+                  Exponent := Exponent * 10 + Digit_Value
+               elsif In_Fraction then
+                  Scale := Scale / Ten
+                  Digit.Convert_From (Digit_Value)
+                  Digit := Digit * Scale
+                  Result := Result + Digit
+               else
+                  Digit.Convert_From (Digit_Value)
+                  Result := Result * Ten
+                  Result := Result + Digit
+               end
+            end
+            Index := Index + 1
+         end
+
+         from
+            Index := 0
+         until
+            Index >= Exponent
+         loop
+            if Exp_Negative then
+               Result := Result / Ten
+            else
+               Result := Result * Ten
+            end
+            Index := Index + 1
+         end
+
+         if Negative then
+            Result := -Result
+         end
+      end
+
    Index_Of (Ch : Character; Start_Index : Integer) : Integer
       require
          Start_Large_Enough : Start_Index >= 1

--- a/share/aquarius/tests/aqua/real_point.aqua
+++ b/share/aquarius/tests/aqua/real_point.aqua
@@ -1,0 +1,37 @@
+class
+   Real_Point
+
+--  A reference class with two REAL attributes, so that a Real has to survive
+--  a two-word object record slot as well as real arguments and results across
+--  a real call.
+
+create
+   make
+
+feature
+
+   make (Initial_X, Initial_Y : Real)
+      do
+         X := Initial_X
+         Y := Initial_Y
+      end
+
+   X : Real
+   Y : Real
+
+   Set_X (New_X : Real)
+      do
+         X := New_X
+      end
+
+   Sum : Real
+      do
+         Result := X + Y
+      end
+
+   Scaled (Factor : Real) : Real_Point
+      do
+         create Result.make (X * Factor, Y * Factor)
+      end
+
+end

--- a/share/aquarius/tests/aqua/test.aqua
+++ b/share/aquarius/tests/aqua/test.aqua
@@ -86,6 +86,18 @@ feature
          Test_List.Append (T)
          create { Test_Literal_Receiver } T
          Test_List.Append (T)
+         create { Test_Real_Literal } T
+         Test_List.Append (T)
+         create { Test_Real_Arithmetic } T
+         Test_List.Append (T)
+         create { Test_Real_Comparison } T
+         Test_List.Append (T)
+         create { Test_Real_Conversion } T
+         Test_List.Append (T)
+         create { Test_Real_In_Container } T
+         Test_List.Append (T)
+         create { Test_Real_Property } T
+         Test_List.Append (T)
          create { Test_Bag_Linked_List } T
          Test_List.Append (T)
          create { Test_Sequence_Linked_List } T

--- a/share/aquarius/tests/aqua/test_real_arithmetic.aqua
+++ b/share/aquarius/tests/aqua/test_real_arithmetic.aqua
@@ -1,0 +1,92 @@
+class
+   Test_Real_Arithmetic
+
+inherit
+   Unit_Test
+
+feature
+
+   Name : String
+      do
+         Result := "test-real-arithmetic"
+      end
+
+   Execute
+      local
+         A, B, R, Zero_Value, One_Value : Real
+      do
+         Success := True
+
+         A := 1.5
+         B := 0.75
+
+         R := A + B
+         Verify ("1.5 + 0.75", R, "2.25")
+
+         R := A - B
+         Verify ("1.5 - 0.75", R, "0.75")
+
+         R := A * B
+         Verify ("1.5 * 0.75", R, "1.125")
+
+         R := A / B
+         Verify ("1.5 / 0.75", R, "2.0")
+
+         --  mod is the IEEE remainder, which rounds the quotient to nearest
+         --  rather than towards zero, so 5.0 mod 3.0 is -1.0 and not 2.0
+         A := 5.0
+         B := 3.0
+         R := A mod B
+         Verify ("5.0 mod 3.0", R, "-1.0")
+
+         A := 2.5
+         R := -A
+         Verify ("-2.5", R, "-2.5")
+
+         R := A.Absolute_Value
+         Verify ("2.5 absolute value", R, "2.5")
+
+         A := -2.5
+         R := A.Absolute_Value
+         Verify ("-2.5 absolute value", R, "2.5")
+
+         --  Zero and One come from the algebra contracts
+         R := Zero_Value.Zero
+         Verify ("Zero", R, "0.0")
+
+         R := One_Value.One
+         Verify ("One", R, "1.0")
+
+         A := 1.0
+         B := 4.0
+         R := A / B
+         Verify ("1.0 / 4.0", R, "0.25")
+
+         --  repeated addition, so that a double survives several round trips
+         --  through locals
+         A := 0.5
+         R := A
+         R := R + A
+         R := R + A
+         R := R + A
+         Verify ("0.5 added four times", R, "2.0")
+
+         --  a value too large for an integer word
+         A := 1.0e10
+         R := A + A
+         Verify ("1.0e10 doubled", R, "2.0e10")
+      end
+
+feature { None }
+
+   Verify (Description : String; Value : Real; Expected : String)
+      do
+         if Success and then Value.To_String /= Expected then
+            Success := False
+            Fail_Message :=
+               Description & " expected " & Expected
+               & ", found " & Value.To_String
+         end
+      end
+
+end

--- a/share/aquarius/tests/aqua/test_real_comparison.aqua
+++ b/share/aquarius/tests/aqua/test_real_comparison.aqua
@@ -1,0 +1,73 @@
+class
+   Test_Real_Comparison
+
+inherit
+   Unit_Test
+
+feature
+
+   Name : String
+      do
+         Result := "test-real-comparison"
+      end
+
+   Execute
+      local
+         A, B, C : Real
+      do
+         Success := True
+
+         A := 1.25
+         B := 2.5
+         C := 1.25
+
+         Verify ("1.25 < 2.5", A < B)
+         Verify ("not 2.5 < 1.25", not (B < A))
+         Verify ("1.25 <= 2.5", A <= B)
+         Verify ("1.25 <= 1.25", A <= C)
+         Verify ("2.5 > 1.25", B > A)
+         Verify ("not 1.25 > 1.25", not (A > C))
+         Verify ("2.5 >= 1.25", B >= A)
+         Verify ("1.25 >= 1.25", A >= C)
+         Verify ("1.25 = 1.25", A = C)
+         Verify ("not 1.25 = 2.5", not (A = B))
+         Verify ("1.25 /= 2.5", A /= B)
+         Verify ("not 1.25 /= 1.25", not (A /= C))
+
+         --  a fraction that is not representable in an integer must not
+         --  compare equal to its truncation
+         A := 0.5
+         B := 0.0
+         Verify ("0.5 /= 0.0", A /= B)
+         Verify ("0.5 > 0.0", A > B)
+
+         --  negative values, where the sign bit rather than the magnitude
+         --  decides the order
+         A := -1.0
+         B := 1.0
+         Verify ("-1.0 < 1.0", A < B)
+         Verify ("not -1.0 > 1.0", not (A > B))
+
+         A := -2.0
+         B := -1.0
+         Verify ("-2.0 < -1.0", A < B)
+         Verify ("-1.0 > -2.0", B > A)
+
+         --  zero compares equal to itself whichever way it was produced
+         A := 0.0
+         B := 1.0
+         C := B - B
+         Verify ("0.0 = 1.0 - 1.0", A = C)
+      end
+
+feature { None }
+
+   Verify (Description : String; Condition : Boolean)
+      do
+         if Success and then not Condition then
+            Success := False
+            Fail_Message := Description & " was false"
+         end
+      end
+
+end

--- a/share/aquarius/tests/aqua/test_real_conversion.aqua
+++ b/share/aquarius/tests/aqua/test_real_conversion.aqua
@@ -1,0 +1,140 @@
+class
+   Test_Real_Conversion
+
+inherit
+   Unit_Test
+
+feature
+
+   Name : String
+      do
+         Result := "test-real-conversion"
+      end
+
+   Execute
+      local
+         R : Real
+         S : String
+         N : Integer
+      do
+         Success := True
+
+         --  integer to real
+         R.Convert_From (7)
+         Verify_Real ("Convert_From (7)", R, "7.0")
+
+         R.Convert_From (-12)
+         Verify_Real ("Convert_From (-12)", R, "-12.0")
+
+         --  real to integer, rounding to nearest
+         R := 2.4
+         N := R.Rounded
+         Verify_Integer ("2.4 rounded", N, 2)
+
+         R := 2.6
+         N := R.Rounded
+         Verify_Integer ("2.6 rounded", N, 3)
+
+         R := -2.6
+         N := R.Rounded
+         Verify_Integer ("-2.6 rounded", N, -3)
+
+         --  Floor, Ceiling and Truncated, all built on Rounded
+         R := 2.9
+         N := R.Floor
+         Verify_Integer ("2.9 floor", N, 2)
+
+         N := R.Ceiling
+         Verify_Integer ("2.9 ceiling", N, 3)
+
+         N := R.Truncated
+         Verify_Integer ("2.9 truncated", N, 2)
+
+         R := -2.9
+         N := R.Floor
+         Verify_Integer ("-2.9 floor", N, -3)
+
+         N := R.Ceiling
+         Verify_Integer ("-2.9 ceiling", N, -2)
+
+         --  truncation is towards zero, so it disagrees with Floor here
+         N := R.Truncated
+         Verify_Integer ("-2.9 truncated", N, -2)
+
+         R := 4.0
+         N := R.Floor
+         Verify_Integer ("4.0 floor", N, 4)
+
+         N := R.Ceiling
+         Verify_Integer ("4.0 ceiling", N, 4)
+
+         --  String to real
+         S := "3.25"
+         R := S.To_Real
+         Verify_Real ("""3.25"" to real", R, "3.25")
+
+         S := "-0.5"
+         R := S.To_Real
+         Verify_Real ("""-0.5"" to real", R, "-0.5")
+
+         S := "12"
+         R := S.To_Real
+         Verify_Real ("""12"" to real", R, "12.0")
+
+         S := "1.5e2"
+         R := S.To_Real
+         Verify_Real ("""1.5e2"" to real", R, "150.0")
+
+         S := "1.5e-2"
+         R := S.To_Real
+         Verify_Real ("""1.5e-2"" to real", R, "0.015")
+
+         --  round trip through To_String
+         R := 6.125
+         S := R.To_String
+         R := S.To_Real
+         Verify_Real ("6.125 round trip", R, "6.125")
+
+         --  magnitudes the fixed form cannot show fall back to an exponent,
+         --  which To_Real reads back
+         R := 2.5e12
+         Verify_Real ("2.5e12", R, "2.5e12")
+
+         S := R.To_String
+         R := S.To_Real
+         Verify_Real ("2.5e12 round trip", R, "2.5e12")
+
+         R := 1.0e-6
+         Verify_Real ("1.0e-6", R, "1.0e-6")
+
+         R := -3.0e10
+         Verify_Real ("-3.0e10", R, "-3.0e10")
+
+         --  a whole part just inside the fixed range stays in fixed form
+         R := 1.0e8
+         Verify_Real ("1.0e8", R, "100000000.0")
+      end
+
+feature { None }
+
+   Verify_Real (Description : String; Value : Real; Expected : String)
+      do
+         if Success and then Value.To_String /= Expected then
+            Success := False
+            Fail_Message :=
+               Description & " expected " & Expected
+               & ", found " & Value.To_String
+         end
+      end
+
+   Verify_Integer (Description : String; Value, Expected : Integer)
+      do
+         if Success and then Value /= Expected then
+            Success := False
+            Fail_Message :=
+               Description & " expected " & Expected.To_String
+               & ", found " & Value.To_String
+         end
+      end
+
+end

--- a/share/aquarius/tests/aqua/test_real_in_container.aqua
+++ b/share/aquarius/tests/aqua/test_real_in_container.aqua
@@ -1,0 +1,70 @@
+class
+   Test_Real_In_Container
+
+inherit
+   Unit_Test
+
+--  A Real as a generic actual.  Containers hold their elements in ordinary
+--  properties, so this only works if a real property really is two words
+--  wide everywhere -- in the object record, in the allocator, and on both
+--  sides of every accessor call.
+
+feature
+
+   Name : String
+      do
+         Result := "test-real-in-container"
+      end
+
+   Execute
+      local
+         L     : Aqua.Containers.Linked_List [Real]
+         R     : Real
+         Total : Real
+      do
+         Success := True
+
+         create L
+         R := 1.5
+         L.Append (R)
+         R := 0.25
+         L.Append (R)
+         R := -2.0
+         L.Append (R)
+
+         if L.Is_Empty then
+            Success := False
+            Fail_Message := "expected a non-empty list"
+         end
+
+         if Success then
+            R := L.First_Element
+            if R.To_String /= "1.5" then
+               Success := False
+               Fail_Message := "first element found " & R.To_String
+            end
+         end
+
+         if Success then
+            R := L.Last_Element
+            if R.To_String /= "-2.0" then
+               Success := False
+               Fail_Message := "last element found " & R.To_String
+            end
+         end
+
+         --  An iteration variable reads its element through the cursor's
+         --  Element feature, which has to be the instantiated version -- the
+         --  generic class's version still returns the one-word formal
+         if Success then
+            across L as Element loop
+               Total := Total + Element
+            end
+            if Total.To_String /= "-0.25" then
+               Success := False
+               Fail_Message := "sum of elements found " & Total.To_String
+            end
+         end
+      end
+
+end

--- a/share/aquarius/tests/aqua/test_real_literal.aqua
+++ b/share/aquarius/tests/aqua/test_real_literal.aqua
@@ -1,0 +1,61 @@
+class
+   Test_Real_Literal
+
+inherit
+   Unit_Test
+
+feature
+
+   Name : String
+      do
+         Result := "test-real-literal"
+      end
+
+   Execute
+      local
+         X, Y, Half, Three : Real
+      do
+         Success := True
+
+         X := 3.5
+         if X.To_String /= "3.5" then
+            Success := False
+            Fail_Message := "3.5 expected ""3.5"", found " & X.To_String
+         end
+
+         --  an integer literal in a real context is a real literal
+         Y := 2
+         if Success and then Y.To_String /= "2.0" then
+            Success := False
+            Fail_Message := "2 as a real expected ""2.0"", found " & Y.To_String
+         end
+
+         --  a negative literal, folded into the literal at parse time
+         X := -0.25
+         if Success and then X.To_String /= "-0.25" then
+            Success := False
+            Fail_Message := "-0.25 expected ""-0.25"", found " & X.To_String
+         end
+
+         --  an exponent
+         X := 1.5e3
+         if Success and then X.To_String /= "1500.0" then
+            Success := False
+            Fail_Message := "1.5e3 expected ""1500.0"", found " & X.To_String
+         end
+
+         --  literals are distinct values, not truncated to integers
+         Half := 0.5
+         Three := 3.0
+         if Success and then Half = Three then
+            Success := False
+            Fail_Message := "0.5 and 3.0 compared equal"
+         end
+
+         if Success and then not (Half < Three) then
+            Success := False
+            Fail_Message := "expected 0.5 < 3.0"
+         end
+      end
+
+end

--- a/share/aquarius/tests/aqua/test_real_property.aqua
+++ b/share/aquarius/tests/aqua/test_real_property.aqua
@@ -1,0 +1,59 @@
+class
+   Test_Real_Property
+
+inherit
+   Unit_Test
+
+feature
+
+   Name : String
+      do
+         Result := "test-real-property"
+      end
+
+   Execute
+      local
+         P, Q : Real_Point
+         R    : Real
+      do
+         Success := True
+
+         create P.make (1.5, 2.25)
+
+         Verify_Real ("X after create", P.X, "1.5")
+         Verify_Real ("Y after create", P.Y, "2.25")
+
+         --  a real returned from a routine of a reference class
+         R := P.Sum
+         Verify_Real ("Sum", R, "3.75")
+
+         --  a real passed as an argument and stored in an attribute
+         P.Set_X (0.5)
+         Verify_Real ("X after Set_X", P.X, "0.5")
+         Verify_Real ("Y unchanged by Set_X", P.Y, "2.25")
+
+         R := P.Sum
+         Verify_Real ("Sum after Set_X", R, "2.75")
+
+         --  a real argument alongside a reference result
+         Q := P.Scaled (2.0)
+         Verify_Real ("scaled X", Q.X, "1.0")
+         Verify_Real ("scaled Y", Q.Y, "4.5")
+
+         --  the original is untouched
+         Verify_Real ("original X after scaling", P.X, "0.5")
+      end
+
+feature { None }
+
+   Verify_Real (Description : String; Value : Real; Expected : String)
+      do
+         if Success and then Value.To_String /= Expected then
+            Success := False
+            Fail_Message :=
+               Description & " expected " & Expected
+               & ", found " & Value.To_String
+         end
+      end
+
+end


### PR DESCRIPTION
…9, #90)

Aqua gains a floating point type.  REAL is an expanded class with one property, so it is a single ack frame slot that happens to be two words wide; the width comes from Tagatha.Floating_Point_Content, never from a slot count. Ack.Is_Floating_Point, Value_Content and Value_Words key off the class link name, and every push, pop, dereference, call and frame declaration in ack now carries the content of its static type.

Scope: arithmetic, ordered comparisons, conversions and output.  Sqrt and the transcendentals are left for a follow-up, so Tagatha.Operator is untouched and the VM's fsqrt is still unreachable.  There is no implicit integer to real promotion either: an integer literal in a real context is a real literal, and anything wider needs an explicit conversion.

Lexing.  A grammar with a separate real token cannot use ada_numeric_literal for its integers, because both match "3.14" -- and since the tokeniser takes the first *declared* class that matches rather than the longest, integer won every time.  New ada_integer_literal and ada_real_literal lexers split the same syntax on the decimal point, and aqua.ebnf declares real first (an .ebnf file cannot carry a comment saying so, hence the note in the syntax doc).

Front end.  N_Real_Constant, with a sign folded into the literal at import time as for integers; Ack.Semantic.Types.Type_Real; a real literal types itself, and an integer literal is accepted where a REAL is expected, in receiver position too.  Object records size a real property as two words, and the allocator initialises both.

Code generation.  New intrinsics fadd, fsubtract, fmultiply, fdivide, real_zero, real_one, to_real and to_integer.  mod, negate and the six comparisons need nothing new: the Aqua backend already picks frem, the sign flip, fcmp and feql from the operand content.

Three bugs this uncovered:

  - Virtual table call thunks sized their scratch register by argument count. A thunk's temporary landed on the second word of a double and destroyed the argument after it, so any routine with a real argument followed by another argument was called with garbage.  Create_Call_Thunk now declares the argument contents too.

  - Ack.Variables.Push_Entity looked "element" up on the iteration cursor's class, which yields the uninstantiated generic formal -- one word wide whatever the actual is.  "across L as X" over a Linked_List [Real] read the high word and flot'ed it, so 1.5 came back as 1.073218e9.  The lookup now goes through the type, which carries the generic bindings.

  - An iteration variable's declared type is the element type but its slot holds the cursor, so it has to be pushed as a reference.

Standard library.  Real sits in the Aqua.Algebra hierarchy (Additive, Multiplicative, Comparable) alongside Integer, with Convert_From, Rounded, Floor, Ceiling, Truncated, Absolute_Value and To_String, plus String.To_Real. Comparison is ordered-only: fcmp reports an unordered pair as equal, so the inequalities are meaningless on NaN, though equality is correct because it uses feql.  Truncation towards zero has no opcode and is synthesised from Rounded.  To_String shows six decimal places with trailing zeros dropped, and normalises anything outside [1.0e-4, 1.0e9) to a mantissa and an exponent, which String.To_Real reads back.

Tests: six new classes covering literals, arithmetic, comparison, conversion, real attributes on a reference class, and a Real as a generic actual.  62 of 62 aqua unit tests pass.