### PR TITLE
feat: a lexical scope per block in Pascal.Checks (#81)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -1,0 +1,24 @@
+class
+   Pascal.Checks.Binding
+
+create
+   Make
+
+--  One name bound to one frame slot, held by Pascal.Checks.Scope (issue #81).
+--  Name is stored lower-cased, because Pascal is case-insensitive; compare it
+--  with String.Equal rather than '=', which is reference equality inside a
+--  generic in the Aqua VM (issue #60).
+
+feature
+
+   Make (Bound_Name : String; Frame_Offset : Integer)
+      do
+         Name := Bound_Name.To_Lower
+         Offset := Frame_Offset
+      end
+
+   Name : String
+
+   Offset : Integer
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
@@ -6,8 +6,9 @@ inherit
 
 --  constant_definition ::= identifier '=' constant. Records the constant's name
 --  in the current entity scope (issue #74). The constant's value is not checked
---  and the name is not entered into the flat offset Scope, so a reference to it
---  in an expression is not yet resolved (minimal semantic pass).
+--  and the name gets no frame slot in Pascal.Checks.Scope -- a constant is not a
+--  variable -- so a reference to it in an expression is not yet resolved
+--  (minimal semantic pass).
 
 feature
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-context.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-context.aqua
@@ -4,12 +4,17 @@ class
 create
    Make
 
---  Mutable holder for the current entity scope during the semantic walk. Held
---  as a system-wide once by Pascal.Checks.Node, so every visitor shares one
---  current-scope pointer. Procedure and function declarations push a child
---  scope on entry and pop it on exit, giving nested entity scopes without
---  touching the flat offset table (Pascal.Checks.Scope) that the code stage
---  uses. A once feature cannot be reassigned, hence this mutable wrapper.
+--  Mutable holder for the current scopes during the semantic walk. Held as a
+--  system-wide once by Pascal.Checks.Node, so every visitor shares one pointer
+--  into each tree. Procedure and function declarations push a child scope on
+--  entry and pop it on exit. A once feature cannot be reassigned, hence this
+--  mutable wrapper.
+--
+--  Two trees are tracked in step: the entity scopes that record declarations for
+--  the test stage and the UI (issue #74), and the Pascal.Checks.Scope tree that
+--  binds names to frame slots for the code stage (issue #81). They are pushed
+--  and popped together by Node.Enter_Scope / Node.Leave_Scope, which is the only
+--  place either pointer moves -- so the two cannot drift apart.
 
 feature
 
@@ -18,6 +23,13 @@ feature
    Set_Current (Scope : Aquarius.Entities.Scope)
       do
          Active_Scope := Scope
+      end
+
+   Active_Frame_Scope : detachable Pascal.Checks.Scope
+
+   Set_Current_Frame_Scope (Frame : Pascal.Checks.Scope)
+      do
+         Active_Frame_Scope := Frame
       end
 
    Make

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
@@ -17,10 +17,10 @@ feature
          N : String
       do
          N := Concatenated_Image
-         if Scope.Is_Declared (N) then
-            Offset := Scope.Offset (N)
+         if Current_Frame_Scope.Is_Declared (N) then
+            Offset := Current_Frame_Scope.Offset (N)
             --  The for-loop control variable is written by the loop.
-            Refer (Current, "write", Scope.Find_Declaration (N))
+            Refer (Current, "write", Current_Frame_Scope.Lookup_Declaration (N))
          else
             Error ("undeclared variable: " & N)
          end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -12,9 +12,10 @@ inherit
 --  so declarations and cross references are recorded in the standard entity
 --  model (readable by the test stage and, eventually, the UI).
 --
---  Scope is the single shared symbol table for the compilation, a once value
---  so every visitor sees the same instance. Declarations populate it (they
---  reduce before the statement part), accesses read it.
+--  Scope is the ROOT of the frame-slot scope tree, a once value so every visitor
+--  sees the same instance. It owns the slot counter for the whole program;
+--  Current_Frame_Scope is the scope declarations and accesses actually use
+--  (issue #81).
 
 feature
 
@@ -23,13 +24,25 @@ feature
          create Result.Make
       end
 
-   --  Entity-model scope tree (issue #74). Separate from the flat offset Scope
-   --  above: this records const/type/var/procedure/function/parameter
-   --  declarations in nested Aquarius.Entities.Scope objects (a child scope per
-   --  procedure/function body), while the flat Scope keeps driving offset
-   --  allocation and variable_access resolution for the code stage. Global_Scope
-   --  is the outermost scope, holding the pre-declared built-in types and
-   --  procedures; the program pushes its own scope beneath it.
+   Current_Frame_Scope : Pascal.Checks.Scope
+      --  Innermost frame scope: the one a declaration lands in and a use
+      --  resolves from. Falls back to the root before the program opens its own.
+      do
+         if attached Context.Active_Frame_Scope as F then
+            Result := F
+         else
+            Result := Scope
+         end
+      end
+
+   --  Entity-model scope tree (issue #74), the second of the two trees. It
+   --  records const/type/var/procedure/function/parameter declarations for the
+   --  test stage and the UI, while the Pascal.Checks.Scope tree above binds
+   --  variable names to frame slots for the code stage. Both nest a child scope
+   --  per procedure/function body, and Enter_Scope / Leave_Scope move them in
+   --  step (issue #81). Global_Scope is the outermost scope, holding the
+   --  pre-declared built-in types and procedures; the program pushes its own
+   --  scope beneath it.
 
    Global_Scope : Aquarius.Entities.Scope
       once
@@ -51,9 +64,17 @@ feature
       end
 
    Enter_Scope (Scope : Aquarius.Entities.Scope)
+      --  Push both trees at once: the entity scope handed in, and a fresh frame
+      --  scope beneath the current one. Both parents are read before either
+      --  pointer moves.
+      local
+         Frame : Pascal.Checks.Scope
       do
          Scope.Set_Parent (Current_Scope)
+         create Frame.Make
+         Frame.Set_Parent (Current_Frame_Scope)
          Context.Set_Current (Scope)
+         Context.Set_Current_Frame_Scope (Frame)
       end
 
    Leave_Scope
@@ -61,6 +82,11 @@ feature
          if attached Context.Active_Scope as C then
             if attached C.Parent as P then
                Context.Set_Current (P)
+            end
+         end
+         if attached Context.Active_Frame_Scope as F then
+            if attached F.Parent as Enclosing then
+               Context.Set_Current_Frame_Scope (Enclosing)
             end
          end
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
@@ -20,6 +20,11 @@ feature
       do
          Ensure_Builtins
          Context.Set_Current (Global_Scope)
+         --  The root frame scope is a once and the plugin reuses one VM across
+         --  files, so empty it here: otherwise slot numbers carry over from the
+         --  last program compiled in this session.
+         Scope.Reset
+         Context.Set_Current_Frame_Scope (Scope)
          create Program_Scope.Make
          Enter_Scope (Program_Scope)
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -4,11 +4,21 @@ class
 create
    Make
 
---  Semantic-stage symbol table: maps a variable name to its 1-based frame-local
---  offset, in declaration order. Owns name resolution and offset allocation;
---  the code stage no longer keeps a symbol table (offsets are handed off via
---  node properties). Single flat main-routine scope for now (procedure-scope
---  isolation deferred, issue #63).
+--  Semantic-stage symbol table: one instance per lexical scope (issue #81),
+--  linked to its enclosing scope by Parent, so a name resolves innermost-first
+--  and an inner declaration shadows an outer one of the same name.
+--
+--  Two kinds of lookup, following Aquarius.Entities.Scope: Find looks in this
+--  scope alone (which is what a duplicate-declaration check needs, so that
+--  shadowing is legal), Lookup walks outward (which is what resolving a use
+--  needs).
+--
+--  Frame slots are allocated from a single counter held by the ROOT scope, not
+--  per scope: Pascal.Generate.Program still emits one routine for the whole
+--  program, so every variable in the program shares one frame and needs its own
+--  slot -- an inner x and an outer x resolve differently but cannot occupy the
+--  same offset. When procedures become routines in their own right, allocation
+--  becomes per-routine and restarts at 1.
 --
 --  Names are stored lower-cased (Pascal is case-insensitive) and compared with
 --  String.Equal (value equality), NOT the '=' operator, which is reference
@@ -18,57 +28,42 @@ feature
 
    Make
       do
-         create Names
+         create Bindings
          create Declarations
-         Count := 0
+         Allocated := 0
       end
 
-   Count : Integer
+   Parent : detachable Pascal.Checks.Scope
 
-   Is_Declared (Name : String) : Boolean
-      local
-         It  : Aqua.Containers.Linked_List_Iterator [String]
-         Key : String
+   Set_Parent (Enclosing : Pascal.Checks.Scope)
       do
-         Key := Name.To_Lower
-         from
-            It := Names.New_Cursor
-         until
-            It.After or else Result
-         loop
-            if It.Element.Equal (Key) then
-               Result := True
-            end
-            It.Next
-         end
+         Parent := Enclosing
       end
+
+   Reset
+      --  Return the scope to its initial state. The shared root scope is a once
+      --  value and the plugin reuses one VM across files, so the root has to be
+      --  emptied at the start of each program or offsets accumulate.
+      do
+         create Bindings
+         create Declarations
+         Allocated := 0
+         Parent := Void
+      end
+
+feature  --  declaring
 
    Declare (Name : String) : Integer
-      do
-         Names.Append (Name.To_Lower)
-         Count := Count + 1
-         Result := Count
-      end
-
-   Offset (Name : String) : Integer
+      --  Bind Name in THIS scope to a freshly allocated frame slot, and return
+      --  the slot. The caller is expected to have checked Find first: declaring
+      --  the same name twice in one scope leaves both bindings, and Find will
+      --  answer with the first.
       local
-         It  : Aqua.Containers.Linked_List_Iterator [String]
-         Key : String
-         I   : Integer
+         B : Pascal.Checks.Binding
       do
-         Key := Name.To_Lower
-         from
-            It := Names.New_Cursor
-            I := 0
-         until
-            It.After
-         loop
-            I := I + 1
-            if It.Element.Equal (Key) then
-               Result := I
-            end
-            It.Next
-         end
+         Result := Allocate
+         create B.Make (Name, Result)
+         Bindings.Append (B)
       end
 
    Add_Declaration (Declaration : Aquarius.Entities.Declaration)
@@ -76,8 +71,45 @@ feature
          Declarations.Append (Declaration)
       end
 
+feature  --  resolving
+
+   Find (Name : String) : detachable Pascal.Checks.Binding
+      --  This scope only
+      local
+         It    : Aqua.Containers.Linked_List_Iterator [Pascal.Checks.Binding]
+         Key   : String
+         Found : Boolean
+      do
+         Key := Name.To_Lower
+         from
+            It := Bindings.New_Cursor
+         until
+            It.After or else Found
+         loop
+            if It.Element.Name.Equal (Key) then
+               Result := It.Element
+               Found := True
+            end
+            It.Next
+         end
+      end
+
+   Lookup (Name : String) : detachable Pascal.Checks.Binding
+      --  This scope, then outward
+      local
+         Own : detachable Pascal.Checks.Binding
+      do
+         Own := Find (Name)
+         if attached Own as B then
+            Result := B
+         elsif attached Parent as P then
+            Result := P.Lookup (Name)
+         end
+      end
+
    Find_Declaration (Name : String)
       : detachable Aquarius.Entities.Declaration
+      --  This scope only
       local
          It    : Aqua.Containers.Linked_List_Iterator
                     [Aquarius.Entities.Declaration]
@@ -100,10 +132,90 @@ feature
          end
       end
 
+   Lookup_Declaration (Name : String)
+      : detachable Aquarius.Entities.Declaration
+      --  This scope, then outward
+      local
+         Own : detachable Aquarius.Entities.Declaration
+      do
+         Own := Find_Declaration (Name)
+         if attached Own as D then
+            Result := D
+         elsif attached Parent as P then
+            Result := P.Lookup_Declaration (Name)
+         end
+      end
+
+   Is_Declared (Name : String) : Boolean
+      --  Visible here or in any enclosing scope
+      local
+         B : detachable Pascal.Checks.Binding
+      do
+         B := Lookup (Name)
+         if attached B as Found then
+            Result := True
+         end
+      end
+
+   Is_Declared_Here (Name : String) : Boolean
+      --  Declared in THIS scope: a redeclaration, as opposed to shadowing
+      local
+         B : detachable Pascal.Checks.Binding
+      do
+         B := Find (Name)
+         if attached B as Found then
+            Result := True
+         end
+      end
+
+   Offset (Name : String) : Integer
+      --  Frame slot of the innermost Name, or 0 if there is none
+      local
+         B : detachable Pascal.Checks.Binding
+      do
+         B := Lookup (Name)
+         if attached B as Found then
+            Result := Found.Offset
+         end
+      end
+
+feature  --  frame
+
+   Count : Integer
+      --  Slots allocated across the whole program, which is what the single
+      --  generated routine needs to reserve.
+      do
+         Result := Allocated_Count
+      end
+
+   Allocated_Count : Integer
+      do
+         if attached Parent as P then
+            Result := P.Allocated_Count
+         else
+            Result := Allocated
+         end
+      end
+
+feature { Pascal.Checks.Scope }
+
+   Allocate : Integer
+      --  Next free slot, always from the root: one frame for the program.
+      do
+         if attached Parent as P then
+            Result := P.Allocate
+         else
+            Allocated := Allocated + 1
+            Result := Allocated
+         end
+      end
+
 feature { None }
 
-   Names : Aqua.Containers.Linked_List [String]
+   Bindings : Aqua.Containers.Linked_List [Pascal.Checks.Binding]
 
    Declarations : Aqua.Containers.Linked_List [Aquarius.Entities.Declaration]
+
+   Allocated : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
@@ -7,8 +7,10 @@ inherit
 --  value_parameter_specification ::= identifier_list ':' type_identifier.
 --  Records each formal value parameter in the current entity scope, which is
 --  the enclosing procedure/function's own child scope (opened by its heading,
---  issue #74). Parameters are not entered into the flat offset Scope, so a
---  reference to one in the body is not yet resolved (minimal semantic pass).
+--  issue #74). Parameters are not given frame slots in Pascal.Checks.Scope, so
+--  a reference to one in the body still fails to resolve -- issue #82. The
+--  heading opens the scope before the parameters reduce, so declaring them here
+--  will put them in the right scope with no further plumbing.
 
 feature
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -29,15 +29,15 @@ feature
    After_Node
       do
          if attached Nm as N then
-            if Scope.Is_Declared (N) then
-               Offset := Scope.Offset (N)
+            if Current_Frame_Scope.Is_Declared (N) then
+               Offset := Current_Frame_Scope.Offset (N)
                --  Record a cross reference to the declared variable: a write
                --  when this access is an assignment target (flagged by the
                --  enclosing assignment_statement), otherwise a read.
                if Is_Target then
-                  Refer (Current, "write", Scope.Find_Declaration (N))
+                  Refer (Current, "write", Current_Frame_Scope.Lookup_Declaration (N))
                else
-                  Refer (Current, "read", Scope.Find_Declaration (N))
+                  Refer (Current, "read", Current_Frame_Scope.Lookup_Declaration (N))
                end
             else
                Error ("undeclared variable: " & N)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
@@ -5,8 +5,12 @@ inherit
    Pascal.Checks.Node
 
 --  variable_declaration ::= identifier_list ':' type_denoter ';'. Allocates a
---  frame-local offset per name in the shared Scope; a name already declared in
---  scope is a semantic error.
+--  frame slot per name in the scope being declared (issue #81).
+--
+--  The duplicate check asks THIS scope only, so redeclaring a name in one block
+--  is an error while shadowing an outer declaration is not -- an inner x is a
+--  new variable with its own slot, and a use of x inside that block resolves to
+--  it rather than to the outer one.
 
 feature
 
@@ -23,15 +27,15 @@ feature
             It.After
          loop
             Name := It.Element
-            if Scope.Is_Declared (Name) then
+            if Current_Frame_Scope.Is_Declared_Here (Name) then
                Error ("duplicate declaration: " & Name)
             else
-               Ignore := Scope.Declare (Name)
+               Ignore := Current_Frame_Scope.Declare (Name)
                --  Record the variable in the standard entity model, keyed
                --  in the scope so a later access can resolve and refer to it.
                create Decl.Make (Name, Name, "variable", Current)
                Environment.Add_Declaration (Decl)
-               Scope.Add_Declaration (Decl)
+               Current_Frame_Scope.Add_Declaration (Decl)
                --  Also record in the current entity scope (issue #74): the
                --  program scope, or a procedure/function's own child scope.
                Current_Scope.Add_Declaration (Decl)

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-block.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-block.aqua
@@ -5,8 +5,9 @@ inherit
    Pascal.Generate.Stmt_Node
 
 --  block ::= ... variable_declaration_part ... statement_part. The variable
---  declarations (earlier siblings) have already populated the shared Scope by
---  the time this reduces; the block's value is the statement part's sequence.
+--  declarations (earlier siblings) have already been bound to frame slots by the
+--  semantic stage by the time this reduces; the block's value is the statement
+--  part's sequence.
 
 feature
 

--- a/share/aquarius/tests/pascal/test_scope_leak.pas
+++ b/share/aquarius/tests/pascal/test_scope_leak.pas
@@ -1,0 +1,23 @@
+{ Lexical scopes, issue #81, the other direction. Expect exactly TWO errors:
+  "undeclared variable: local_to_p" and "duplicate declaration: dup".
+
+  A procedure's local is not visible outside it, and a name declared twice in
+  ONE block is still an error -- shadowing is legal, redeclaring is not.
+
+  Check with: bin/aquarius --check test_scope_leak.pas }
+
+program Test_Scope_Leak;
+
+var
+   dup : integer;
+   dup : integer;     { error: same block, not shadowing }
+
+procedure P;
+   var local_to_p : integer;
+begin
+   local_to_p := 1
+end;
+
+begin
+   local_to_p := 2    { error: P's local is out of scope here }
+end.

--- a/share/aquarius/tests/pascal/test_scopes.pas
+++ b/share/aquarius/tests/pascal/test_scopes.pas
@@ -1,0 +1,40 @@
+{ Lexical scopes, issue #81. Expect NO errors.
+
+  Each block gets its own scope, so an inner declaration shadows an outer one of
+  the same name instead of colliding with it, and sibling procedures may reuse a
+  name freely. Every variable still gets a distinct frame slot: one routine is
+  generated for the whole program, so the slots must not overlap even where the
+  names do.
+
+  Check with: bin/aquarius --check test_scopes.pas }
+
+program Test_Scopes;
+
+var
+   x : integer;      { program x }
+   shared : integer;
+
+procedure Outer;
+   var x : integer;  { shadows the program x }
+
+   procedure Inner;
+      var x : integer;   { shadows Outer's x }
+   begin
+      x := 3;           { Inner's x }
+      shared := 3       { reaches outward to the program's shared }
+   end;
+
+begin
+   x := 4                { Outer's x }
+end;
+
+procedure Sibling;
+   var x : integer;      { same name as Outer's local, a different variable }
+begin
+   x := 5
+end;
+
+begin
+   x := 1;               { the program's x }
+   shared := 0
+end.


### PR DESCRIPTION
Declarations were global: every variable in the program went into one flat table where the offset was a name's position in it.  That produced both a false error and a missing one -- an inner var x collided with an outer x instead of shadowing it, and a procedure local stayed visible to the whole program.

Pascal.Checks.Scope is now one instance per lexical scope, linked outward by Parent, holding Pascal.Checks.Binding records rather than bare names.  It offers the same two lookups as Aquarius.Entities.Scope: Find for this scope alone, which is what a duplicate check needs so that shadowing stays legal, and Lookup walking outward, which is what resolving a use needs.

Slots are still allocated from one counter, held by the root scope.  That is deliberate: Pascal.Generate.Program emits a single routine for the whole program, so an inner x and an outer x resolve differently but cannot share an offset.  Allocation becomes per-routine when procedures become routines in their own right.  test_scopes.pas declares five variables of which three are named x, and the frame reserves five words.

The entity scope tree from #74 already nested, with its push and pop sites in the right places, so Enter_Scope and Leave_Scope now move both trees together and remain the only place either pointer changes -- the two cannot drift.  That is why this is a small change.

The root scope is a once and the plugin reuses one VM across files, so Program.Before_Node empties it; otherwise slot numbers carried over from the previous program compiled in the same session.

Fewer errors on the real programs, not more, which is the opposite of what I expected: startrek 409 -> 387, basics 471 -> 459, prettyprint 565 -> 559, pl0 271 -> 268.  Breaking startrek down, duplicate declarations fall from 26 to 0 -- sibling procedures reusing a local name no longer collide, because each scope closes before the next opens -- while undeclared variables rise from 383 to 387, those being references that used to reach a leaked procedure local.  The rest of that 387 is parameters (#82) and function names (#84, #85), which #81 cannot touch.