### PR TITLE
feat: procedure and function parameters in scope (#82)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -2,23 +2,47 @@ class
    Pascal.Checks.Binding
 
 create
-   Make
+   Make_Local, Make_Argument
 
---  One name bound to one frame slot, held by Pascal.Checks.Scope (issue #81).
+--  One name bound to one slot of the enclosing routine's frame, held by
+--  Pascal.Checks.Scope (issue #81).
+--
+--  Tagatha keeps arguments and locals in separate index spaces -- Push_Argument
+--  and Push_Local take their own 1-based index -- so a binding has to say which
+--  space its Offset belongs to (issue #82). By_Reference marks a Pascal 'var'
+--  parameter, which is passed by address: it resolves like any other name, but
+--  reading it needs a dereference and writing it an indirect store, neither of
+--  which Ast.Expression.Argument can express yet.
+--
 --  Name is stored lower-cased, because Pascal is case-insensitive; compare it
 --  with String.Equal rather than '=', which is reference equality inside a
 --  generic in the Aqua VM (issue #60).
 
 feature
 
-   Make (Bound_Name : String; Frame_Offset : Integer)
+   Make_Local (Bound_Name : String; Frame_Slot : Integer)
       do
          Name := Bound_Name.To_Lower
-         Offset := Frame_Offset
+         Offset := Frame_Slot
+      end
+
+   Make_Argument (Bound_Name           : String
+                  Argument_Index       : Integer
+                  Passed_By_Reference  : Boolean)
+      do
+         Name := Bound_Name.To_Lower
+         Offset := Argument_Index
+         Is_Argument := True
+         By_Reference := Passed_By_Reference
       end
 
    Name : String
 
    Offset : Integer
+      --  Frame slot for a local, argument index for an argument; both 1-based
+
+   Is_Argument : Boolean
+
+   By_Reference : Boolean
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
@@ -5,20 +5,29 @@ inherit
    Pascal.Checks.Node
 
 --  control_variable ::= variable_identifier (the for-loop variable). Resolves
---  its frame-local offset and exposes it as Offset; the code stage reads it via
---  type-injection (#66). Undeclared name is a semantic error.
+--  its binding and exposes the offset plus whether it is an argument rather than
+--  a local (issue #82); the code stage reads them via type-injection (#66).
+--  Undeclared name is a semantic error.
 
 feature
 
    Offset : Integer
 
+   Is_Argument : Boolean
+
+   By_Reference : Boolean
+
    After_Node
       local
          N : String
+         B : detachable Pascal.Checks.Binding
       do
          N := Concatenated_Image
-         if Current_Frame_Scope.Is_Declared (N) then
-            Offset := Current_Frame_Scope.Offset (N)
+         B := Current_Frame_Scope.Lookup (N)
+         if attached B as Bound then
+            Offset := Bound.Offset
+            Is_Argument := Bound.Is_Argument
+            By_Reference := Bound.By_Reference
             --  The for-loop control variable is written by the loop.
             Refer (Current, "write", Current_Frame_Scope.Lookup_Declaration (N))
          else

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -102,6 +102,41 @@ feature
          Current_Scope.Add_Declaration (Result)
       end
 
+   Declare_Parameters (List         : Pascal.Checks.Identifier_List
+                       By_Reference : Boolean
+                       Category     : String)
+      --  Bind each name in List as an argument of the routine whose scope is
+      --  current (issue #82). Shared by the value and var parameter
+      --  specifications, which differ only in By_Reference and Category.
+      --
+      --  The redeclaration check is Is_Declared_Here, so repeating a name within
+      --  one parameter list, or between the parameters and the body's locals, is
+      --  an error -- they share the routine's scope -- while shadowing a name
+      --  from an enclosing scope is not.
+      local
+         It     : Aqua.Containers.Linked_List_Iterator [String]
+         Name   : String
+         Ignore : Integer
+         Decl   : Aquarius.Entities.Declaration
+      do
+         from
+            It := List.Names.New_Cursor
+         until
+            It.After
+         loop
+            Name := It.Element
+            if Current_Frame_Scope.Is_Declared_Here (Name) then
+               Error ("duplicate declaration: " & Name)
+            else
+               Ignore :=
+                  Current_Frame_Scope.Declare_Argument (Name, By_Reference)
+               Decl := Record_Declaration (Current, Name, Category)
+               Current_Frame_Scope.Add_Declaration (Decl)
+            end
+            It.Next
+         end
+      end
+
    Ensure_Builtins
       --  Pre-declare Pascal's required built-in types and I/O procedures once,
       --  in Global_Scope. Guarded on emptiness because the plugin reuses one VM

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -13,12 +13,20 @@ create
 --  shadowing is legal), Lookup walks outward (which is what resolving a use
 --  needs).
 --
---  Frame slots are allocated from a single counter held by the ROOT scope, not
---  per scope: Pascal.Generate.Program still emits one routine for the whole
---  program, so every variable in the program shares one frame and needs its own
---  slot -- an inner x and an outer x resolve differently but cannot occupy the
---  same offset. When procedures become routines in their own right, allocation
---  becomes per-routine and restarts at 1.
+--  Locals and arguments are allocated differently, and the asymmetry is
+--  deliberate (issue #82).
+--
+--  Local slots come from a single counter held by the ROOT scope, because
+--  Pascal.Generate.Program still emits one routine for the whole program: every
+--  variable shares one frame and needs its own slot, so an inner x and an outer
+--  x resolve differently but cannot occupy the same offset.
+--
+--  Argument indices count from 1 in EACH routine scope, with no delegation --
+--  that is what a routine's own signature means, and it makes a nested
+--  procedure's parameters independent of its parent's for free.
+--
+--  When procedure bodies become routines in their own right, locals will stop
+--  delegating too and both will be per-routine.
 --
 --  Names are stored lower-cased (Pascal is case-insensitive) and compared with
 --  String.Equal (value equality), NOT the '=' operator, which is reference
@@ -31,6 +39,7 @@ feature
          create Bindings
          create Declarations
          Allocated := 0
+         Allocated_Arguments := 0
       end
 
    Parent : detachable Pascal.Checks.Scope
@@ -48,12 +57,13 @@ feature
          create Bindings
          create Declarations
          Allocated := 0
+         Allocated_Arguments := 0
          Parent := Void
       end
 
 feature  --  declaring
 
-   Declare (Name : String) : Integer
+   Declare_Local (Name : String) : Integer
       --  Bind Name in THIS scope to a freshly allocated frame slot, and return
       --  the slot. The caller is expected to have checked Find first: declaring
       --  the same name twice in one scope leaves both bindings, and Find will
@@ -62,7 +72,20 @@ feature  --  declaring
          B : Pascal.Checks.Binding
       do
          Result := Allocate
-         create B.Make (Name, Result)
+         create B.Make_Local (Name, Result)
+         Bindings.Append (B)
+      end
+
+   Declare_Argument (Name : String; By_Reference : Boolean) : Integer
+      --  Bind Name in THIS scope to the next argument index of the routine this
+      --  scope belongs to, and return the index. Same caller contract as
+      --  Declare_Local: check Find first.
+      local
+         B : Pascal.Checks.Binding
+      do
+         Allocated_Arguments := Allocated_Arguments + 1
+         Result := Allocated_Arguments
+         create B.Make_Argument (Name, Result, By_Reference)
          Bindings.Append (B)
       end
 
@@ -182,10 +205,17 @@ feature  --  resolving
 feature  --  frame
 
    Count : Integer
-      --  Slots allocated across the whole program, which is what the single
-      --  generated routine needs to reserve.
+      --  Local slots allocated across the whole program, which is what the
+      --  single generated routine needs to reserve.
       do
          Result := Allocated_Count
+      end
+
+   Argument_Count : Integer
+      --  Arguments declared in THIS scope: the signature of the routine it
+      --  belongs to, for when procedure bodies become routines.
+      do
+         Result := Allocated_Arguments
       end
 
    Allocated_Count : Integer
@@ -217,5 +247,9 @@ feature { None }
    Declarations : Aqua.Containers.Linked_List [Aquarius.Entities.Declaration]
 
    Allocated : Integer
+      --  Local slots; only the root's copy is used
+
+   Allocated_Arguments : Integer
+      --  Arguments of this scope's own routine
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
@@ -5,28 +5,20 @@ inherit
    Pascal.Checks.Node
 
 --  value_parameter_specification ::= identifier_list ':' type_identifier.
---  Records each formal value parameter in the current entity scope, which is
---  the enclosing procedure/function's own child scope (opened by its heading,
---  issue #74). Parameters are not given frame slots in Pascal.Checks.Scope, so
---  a reference to one in the body still fails to resolve -- issue #82. The
---  heading opens the scope before the parameters reduce, so declaring them here
---  will put them in the right scope with no further plumbing.
+--  Binds each formal value parameter to an argument index of the enclosing
+--  routine (issue #82), in the scope its heading opened -- which is also the
+--  scope the body's locals land in, so a local that repeats a parameter's name
+--  is caught as a redeclaration for free.
+--
+--  Also recorded in the entity model as a "parameter" (issue #74), and in the
+--  frame scope's declarations so a reference to the parameter can resolve to it
+--  and record a cross reference.
 
 feature
 
    After_Identifier_List (Child : Pascal.Checks.Identifier_List)
-      local
-         It     : Aqua.Containers.Linked_List_Iterator [String]
-         Ignore : Aquarius.Entities.Declaration
       do
-         from
-            It := Child.Names.New_Cursor
-         until
-            It.After
-         loop
-            Ignore := Record_Declaration (Current, It.Element, "parameter")
-            It.Next
-         end
+         Declare_Parameters (Child, False, "parameter")
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -5,14 +5,21 @@ inherit
    Pascal.Checks.Node
 
 --  variable_access ::= variable_identifier { variable_suffix }. Resolves the
---  name to its frame-local offset and exposes it as the public Offset field.
---  The code-stage Pascal.Generate.Variable_Access for the same node receives
---  this object by type-injection (issue #66) and reads Offset directly. An
---  undeclared name is a semantic error. Scalars only.
+--  name to its binding and exposes what the code stage needs: the offset, and
+--  whether that offset indexes the routine's arguments or its locals -- separate
+--  spaces in Tagatha, so the code stage has to know which (issue #82).
+--  Pascal.Generate.Variable_Access for the same node receives this object by
+--  type-injection (issue #66) and reads the fields directly. An undeclared name
+--  is a semantic error. Scalars only.
 
 feature
 
    Offset : Integer
+
+   Is_Argument : Boolean
+
+   By_Reference : Boolean
+      --  A 'var' parameter: the argument holds an address, not a value
 
    Is_Target : Boolean
 
@@ -27,10 +34,15 @@ feature
       end
 
    After_Node
+      local
+         B : detachable Pascal.Checks.Binding
       do
          if attached Nm as N then
-            if Current_Frame_Scope.Is_Declared (N) then
-               Offset := Current_Frame_Scope.Offset (N)
+            B := Current_Frame_Scope.Lookup (N)
+            if attached B as Bound then
+               Offset := Bound.Offset
+               Is_Argument := Bound.Is_Argument
+               By_Reference := Bound.By_Reference
                --  Record a cross reference to the declared variable: a write
                --  when this access is an assignment target (flagged by the
                --  enclosing assignment_statement), otherwise a read.

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
@@ -30,7 +30,7 @@ feature
             if Current_Frame_Scope.Is_Declared_Here (Name) then
                Error ("duplicate declaration: " & Name)
             else
-               Ignore := Current_Frame_Scope.Declare (Name)
+               Ignore := Current_Frame_Scope.Declare_Local (Name)
                --  Record the variable in the standard entity model, keyed
                --  in the scope so a later access can resolve and refer to it.
                create Decl.Make (Name, Name, "variable", Current)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_parameter_specification.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_parameter_specification.aqua
@@ -6,23 +6,20 @@ inherit
 
 --  variable_parameter_specification ::= 'var' identifier_list ':'
 --  type_identifier. As value_parameter_specification, but the parameter is
---  passed by reference; recorded with the "var-parameter" category (issue #74).
+--  passed by reference, so its binding is marked By_Reference and it is recorded
+--  with the "var-parameter" category (issue #74).
+--
+--  Resolving one is no different from resolving a value parameter; generating
+--  one is, and cannot be done yet -- reading through the reference needs a
+--  dereference and writing it an indirect store, and neither
+--  Ast.Expression.Argument nor Tagatha's Push_Argument / Pop_Argument carries a
+--  reference flag the way Push_Local does.
 
 feature
 
    After_Identifier_List (Child : Pascal.Checks.Identifier_List)
-      local
-         It     : Aqua.Containers.Linked_List_Iterator [String]
-         Ignore : Aquarius.Entities.Declaration
       do
-         from
-            It := Child.Names.New_Cursor
-         until
-            It.After
-         loop
-            Ignore := Record_Declaration (Current, It.Element, "var-parameter")
-            It.Next
-         end
+         Declare_Parameters (Child, True, "var-parameter")
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-control_variable.aqua
@@ -6,7 +6,8 @@ inherit
 
 --  Leaf: control_variable ::= variable_identifier. The semantic-stage
 --  Pascal.Checks.Control_Variable for this node is injected by type (#66); the
---  enclosing for_statement reads the resolved offset via Offset.
+--  enclosing for_statement reads the resolved offset via Offset, and whether it
+--  indexes arguments rather than locals via Is_Argument (issue #82).
 
 feature
 
@@ -14,10 +15,18 @@ feature
 
    Offset : Integer
 
+   Is_Argument : Boolean
+
    After_Node
       do
          if attached Checks as C then
             Offset := C.Offset
+            Is_Argument := C.Is_Argument
+            if C.By_Reference then
+               --  See Pascal.Generate.Variable_Access: a var parameter holds an
+               --  address, which the IR cannot express for an argument yet.
+               Error ("not implemented: a var parameter as a loop variable")
+            end
          end
       end
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-for_statement.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-for_statement.aqua
@@ -20,6 +20,7 @@ feature
    After_Control_Variable (Child : Pascal.Generate.Control_Variable)
       do
          Off_Value := Child.Offset
+         CV_Is_Argument := Child.Is_Argument
          Have_CV := True
       end
 
@@ -70,11 +71,11 @@ feature
                         Cond_Op := O.Less_Equal
                         Incr_Op := O.Add
                      end
-                     create Init_Assign.Make (Void, Current, New_Local (Off), I0)
-                     create Cond_Expr.Make (Void, Current, Cond_Op, New_Local (Off), F0)
+                     create Init_Assign.Make (Void, Current, New_Target (Off), I0)
+                     create Cond_Expr.Make (Void, Current, Cond_Op, New_Target (Off), F0)
                      create One.Make_Integer (Void, Current, 1)
-                     create Incr_Expr.Make (Void, Current, Incr_Op, New_Local (Off), One)
-                     create Incr_Assign.Make (Void, Current, New_Local (Off), Incr_Expr)
+                     create Incr_Expr.Make (Void, Current, Incr_Op, New_Target (Off), One)
+                     create Incr_Assign.Make (Void, Current, New_Target (Off), Incr_Expr)
                      create Loop_Body.Make (Void, Current)
                      Loop_Body.Append (B0)
                      Loop_Body.Append (Incr_Assign)
@@ -91,16 +92,30 @@ feature
 
 feature { None }
 
-   Off_Value : Integer
-   Have_CV   : Boolean
-   Init      : detachable Ast.Expression
-   Final     : detachable Ast.Expression
-   Body      : detachable Ast.Statement
-   Down      : Boolean
+   Off_Value      : Integer
+   CV_Is_Argument : Boolean
+   Have_CV        : Boolean
+   Init           : detachable Ast.Expression
+   Final          : detachable Ast.Expression
+   Body           : detachable Ast.Statement
+   Down           : Boolean
 
-   New_Local (Off : Integer) : Ast.Expression.Local_Variable
+   New_Target (Off : Integer) : Ast.Expression
+      --  A fresh node for the control variable, one per use: the loop reads and
+      --  writes it four times, and an Ast node belongs to one position in the
+      --  tree. Argument or local according to what the semantic stage resolved
+      --  (issue #82).
+      local
+         A : Ast.Expression.Argument
+         L : Ast.Expression.Local_Variable
       do
-         create Result.Make (Void, Current, Off)
+         if CV_Is_Argument then
+            create A.Make (Void, Current, Off)
+            Result := A
+         else
+            create L.Make (Void, Current, Off)
+            Result := L
+         end
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
@@ -8,8 +8,14 @@ inherit
 --  stage's Pascal.Checks.Variable_Access for the SAME node is injected here by
 --  type (issue #66): the framework populates Checks with that node's
 --  earlier-stage object, so the resolved offset is read as a typed field
---  (Checks.Offset) -- no property-bag marshalling. Yields an
---  Ast.Expression.Local_Variable (rvalue and assignment target).
+--  (Checks.Offset) -- no property-bag marshalling.
+--
+--  Yields an Ast.Expression.Argument for a parameter and an
+--  Ast.Expression.Local_Variable otherwise (issue #82); both serve as rvalue and
+--  assignment target. Note that no program reaches the argument branch yet: it
+--  needs a reference to a parameter, which can only appear in a procedure or
+--  function body, and those are not lowered at all -- the program routine takes
+--  no arguments.
 
 feature
 
@@ -18,10 +24,23 @@ feature
    After_Node
       local
          L : Ast.Expression.Local_Variable
+         A : Ast.Expression.Argument
       do
          if attached Checks as C then
-            create L.Make (Void, Current, C.Offset)
-            Set_Expr (L)
+            if C.By_Reference then
+               --  A 'var' parameter holds an address: reading it needs a
+               --  dereference and writing it an indirect store, and neither
+               --  Ast.Expression.Argument nor Tagatha's Push_Argument /
+               --  Pop_Argument carries a reference flag the way Push_Local does.
+               --  Refuse rather than silently emit code that copies the address.
+               Error ("not implemented: code for a var parameter")
+            elsif C.Is_Argument then
+               create A.Make (Void, Current, C.Offset)
+               Set_Expr (A)
+            else
+               create L.Make (Void, Current, C.Offset)
+               Set_Expr (L)
+            end
          else
             Error ("internal: variable_access not resolved by semantic stage")
          end

--- a/share/aquarius/tests/pascal/test_parameter_errors.pas
+++ b/share/aquarius/tests/pascal/test_parameter_errors.pas
@@ -1,0 +1,43 @@
+{ Parameters, the error cases, issue #82. Expect exactly THREE errors:
+
+     duplicate declaration: n      -- a local repeats a parameter name
+     duplicate declaration: dup    -- one parameter list repeats a name
+     undeclared variable: hidden   -- another routine's parameter
+
+  Parameters and locals share the routine's scope, so repeating a name in either
+  is a redeclaration -- while shadowing a name from an ENCLOSING scope is legal,
+  as test_parameters.pas shows.
+
+  Check with: bin/aquarius --check test_parameter_errors.pas }
+
+program Test_Parameter_Errors;
+
+var
+   g : integer;
+
+procedure Repeats_A_Parameter(n : integer);
+   var n : integer;        { error: same scope as the parameter }
+begin
+   g := n
+end;
+
+procedure Repeats_In_The_List(dup : integer; dup : integer);
+begin
+   g := dup
+end;
+
+procedure Owns_It(hidden : integer);
+begin
+   g := hidden             { fine: its own parameter }
+end;
+
+procedure Cannot_See_It;
+begin
+   g := hidden             { error: belongs to Owns_It }
+end;
+
+begin
+   g := 0;
+   Owns_It(1);
+   Cannot_See_It
+end.

--- a/share/aquarius/tests/pascal/test_parameters.pas
+++ b/share/aquarius/tests/pascal/test_parameters.pas
@@ -1,0 +1,67 @@
+{ Procedure and function parameters in scope, issue #82. Expect NO errors.
+
+  A parameter is a name in the routine's own scope, so it resolves in the body
+  like a local does, and it may shadow an outer name. Parameters and locals
+  share that scope, which is what makes a local repeating a parameter name an
+  error -- see test_parameter_errors.pas for that direction.
+
+  Check with: bin/aquarius --check test_parameters.pas }
+
+program Test_Parameters(input, output);
+
+var
+   g : integer;      { global, reachable from every body below }
+   x : integer;      { shadowed by parameters named x }
+
+procedure One_Value(x : integer);
+begin
+   writeln(x)        { the parameter, not the program's x }
+end;
+
+procedure Several(a, b : integer; c : integer);
+   var t : integer;  { a local alongside the parameters }
+begin
+   t := a + b;
+   t := t + c;
+   g := t            { still reaches the global }
+end;
+
+procedure By_Ref(var total : integer; increment : integer);
+begin
+   total := total + increment
+end;
+
+procedure Outer(x : integer);
+
+   procedure Inner(x : integer);   { shadows Outer's parameter }
+   begin
+      writeln(x)                   { Inner's x }
+   end;
+
+begin
+   Inner(x)                        { Outer's x, passed on }
+end;
+
+function Add(left, right : integer) : integer;
+   var sum : integer;
+begin
+   sum := left + right;
+   writeln(sum)
+end;
+
+procedure Loops(limit : integer);
+   var i : integer;
+begin
+   for i := 1 to limit do          { a parameter as the loop bound }
+      g := g + i
+end;
+
+begin
+   x := 0;
+   g := 0;
+   One_Value(1);
+   Several(1, 2, 3);
+   By_Ref(g, 1);
+   Outer(2);
+   Loops(3)
+end.


### PR DESCRIPTION
Parameters were recorded in the entity model but bound to nothing, so every reference to one in a body was reported as an undeclared variable.  They now get an argument index in the scope their heading opened -- which is the scope the body's locals land in too, so a local repeating a parameter name is caught as a redeclaration without any extra code, while shadowing an enclosing name stays legal.

A binding therefore has to say which index space its offset belongs to, because Tagatha keeps arguments and locals separate: Binding gains Make_Local and Make_Argument, Is_Argument and By_Reference.  Argument indices count from 1 in each routine scope with no delegation, unlike local slots, which still come from the root scope because one routine is generated for the whole program.  That asymmetry is commented where it lives; both become per-routine once procedure bodies are lowered.

Declare_Parameters on Pascal.Checks.Node does the work for both specifications, which differ only in By_Reference and category.

On the code side variable_access resolves a binding once rather than walking the scope three times, and yields an Ast.Expression.Argument for a parameter or an Ast.Expression.Local_Variable otherwise; the for statement does the same for its control variable, which it reads and writes four times, so New_Local became New_Target.  No program reaches the argument branch yet: a parameter reference can only appear in a procedure or function body, and those are not lowered at all.

A var parameter resolves like any other name but cannot be generated: it holds an address, so reading it needs a dereference and writing it an indirect store, and neither Ast.Expression.Argument nor Push_Argument / Pop_Argument carries a reference flag the way Push_Local does.  Both generate visitors refuse with "not implemented" rather than emit code that copies the address as a value.

Undeclared-variable reports fall sharply: startrek 387 -> 337, basics 459 ->
369, prettyprint 559 -> 481, pl0 268 -> 216, so 270 fewer in total.  Classifying what remains in startrek, none of it is a parameter: constants, function results assigned through the function name (#84), standard functions such as ROUND and SUCC (#83), and record fields referenced inside a with statement.

test_parameters.pas covers value and var parameters, several groups, parameters beside locals, a nested procedure whose parameter shadows its parent's, a function's parameters and a parameter as a loop bound; test_parameter_errors.pas pins the three error cases.  For-loop code generation is byte-identical to before the New_Target change.