### PR TITLE
feat: resolve constant identifiers in Pascal.Checks (#103)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -2,7 +2,7 @@ class
    Pascal.Checks.Binding
 
 create
-   Make_Local, Make_Argument
+   Make_Local, Make_Argument, Make_Constant
 
 --  One name bound to one slot of the enclosing routine's frame, held by
 --  Pascal.Checks.Scope (issue #81).
@@ -13,6 +13,11 @@ create
 --  parameter, which is passed by address: it resolves like any other name, but
 --  reading it needs a dereference and writing it an indirect store, neither of
 --  which Ast.Expression.Argument can express yet.
+--
+--  A constant binds to a value rather than to storage (issue #103): it has no
+--  offset in either space, and a use of it generates the literal instead of a
+--  load. That is also why a constant works where a value is needed before the
+--  program runs, as in array [1 .. maxpgm].
 --
 --  Name is stored lower-cased, because Pascal is case-insensitive; compare it
 --  with String.Equal rather than '=', which is reference equality inside a
@@ -36,12 +41,25 @@ feature
          By_Reference := Passed_By_Reference
       end
 
+   Make_Constant (Bound_Name : String; Constant_Value : Integer)
+      do
+         Name := Bound_Name.To_Lower
+         Value := Constant_Value
+         Is_Constant := True
+      end
+
    Name : String
 
    Offset : Integer
-      --  Frame slot for a local, argument index for an argument; both 1-based
+      --  Frame slot for a local, argument index for an argument; both 1-based.
+      --  Meaningless for a constant, which occupies no storage.
+
+   Value : Integer
+      --  The value of a constant; meaningless for anything else
 
    Is_Argument : Boolean
+
+   Is_Constant : Boolean
 
    By_Reference : Boolean
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-constant.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-constant.aqua
@@ -1,0 +1,154 @@
+class
+   Pascal.Checks.Constant
+
+inherit
+   Pascal.Checks.Node
+
+--  constant ::= [ sign ] ( numeric_literal | constant_identifier )
+--            | string_literal
+--
+--  Evaluates the constant to an integer (issue #103), which
+--  Pascal.Checks.Constant_Definition then binds to the name being defined.
+--  Is_Known says whether that succeeded; when it did not, the definition is
+--  recorded without a value rather than reported as an error here.
+--
+--  Handled: a signed or unsigned integer literal, a character literal (its code
+--  point -- Pascal programs use these as symbols, 'K' for a klingon and so on),
+--  and a reference to an earlier constant, with or without a sign.
+--
+--  NOT handled, deliberately: a real literal, which needs Ast.Expression's real
+--  literal and a place to keep a Real (#87, #88), and a string literal of more
+--  than one character, which needs somewhere to put the text. Both leave
+--  Is_Known False. The real case has to be tested for explicitly: "3.14" would
+--  otherwise be fed to String.To_Integer, which reads what it can and returns a
+--  quietly wrong answer.
+--
+--  The production is read from Concatenated_Image rather than through child
+--  visitors, because its alternatives are token classes and a rule that is just
+--  an identifier: the image is the sign glued to the digits or to the name
+--  ("-7", "maxpgm"). String.To_Integer does not accept a sign (issue #40), so
+--  the sign is peeled off here, as Wir.Generate.Signed_Integer does.
+
+feature
+
+   Value : Integer
+
+   Is_Known : Boolean
+
+   After_Node
+      local
+         Image      : String
+         Rest       : String
+         Negative   : Boolean
+         First      : Character
+         Referenced : detachable Pascal.Checks.Binding
+      do
+         Image := Concatenated_Image
+         if Image.Length > 0 then
+            First := Image.Element (1)
+            if First = '-' then
+               Negative := True
+               Rest := Image.Slice (2, Image.Length)
+            elsif First = '+' then
+               Rest := Image.Slice (2, Image.Length)
+            else
+               Rest := Image
+            end
+
+            if Rest.Length > 0 then
+               if Is_Digit (Rest.Element (1)) then
+                  if not Looks_Real (Rest) then
+                     Value := Rest.To_Integer
+                     Is_Known := True
+                  end
+               elsif Is_Quote (Rest.Element (1)) then
+                  Read_Character_Literal (Rest)
+               else
+                  --  A constant defined in terms of an earlier one, which the
+                  --  declaration order guarantees is already in scope.
+                  Referenced := Current_Frame_Scope.Lookup (Rest)
+                  if attached Referenced as B then
+                     if B.Is_Constant then
+                        Value := B.Value
+                        Is_Known := True
+                     end
+                  end
+               end
+            end
+
+            if Is_Known then
+               if Negative then
+                  Value := 0 - Value
+               end
+            end
+         end
+      end
+
+feature { None }
+
+   Is_Digit (Ch : Character) : Boolean
+      --  Character has no Is_Digit, so compare code points: '0' is 48, '9' is 57
+      local
+         Code : Integer
+      do
+         Code.Convert_From (Ch.UTF_32_Code)
+         Result := Code >= 48 and then Code <= 57
+      end
+
+   Looks_Real (Text : String) : Boolean
+      --  A decimal point or an exponent makes it a real literal
+      local
+         Index : Integer
+         Ch    : Character
+      do
+         from
+            Index := 1
+         until
+            Index > Text.Length or else Result
+         loop
+            Ch := Text.Element (Index)
+            if Ch = '.' or else Ch = 'e' or else Ch = 'E' then
+               Result := True
+            end
+            Index := Index + 1
+         end
+      end
+
+   Is_Quote (Ch : Character) : Boolean
+      --  The apostrophe is written ''' -- character_constant is !\'[.]\'!, so
+      --  the middle character may itself be a quote. The double quote is
+      --  accepted too, because this Pascal lexer takes either around a string.
+      do
+         Result := Ch = ''' or else Ch = '"'
+      end
+
+   Read_Character_Literal (Text : String)
+      --  A single-character literal is its code point. Pascal doubles the quote
+      --  to include one, so four quotes denote the quote character itself.
+      --  Anything longer is a string, which has no integer value.
+      local
+         Inner : String
+         Code  : Integer
+      do
+         if Text.Length >= 2 then
+            Inner := Text.Slice (2, Text.Length - 1)
+            --  Convert into a LOCAL and assign: Convert_From is the
+            --  replace-current intrinsic, and calling it on an attribute leaves
+            --  the attribute untouched -- the char came out as 0.
+            if Inner.Length = 1 then
+               Code.Convert_From (Inner.Element (1).UTF_32_Code)
+               Value := Code
+               Is_Known := True
+            elsif Inner.Length = 2 then
+               if Is_Quote (Inner.Element (1))
+                 and then Is_Quote (Inner.Element (2))
+               then
+                  Code.Convert_From (Inner.Element (1).UTF_32_Code)
+                  Value := Code
+                  Is_Known := True
+               end
+            end
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
@@ -4,19 +4,53 @@ class
 inherit
    Pascal.Checks.Node
 
---  constant_definition ::= identifier '=' constant. Records the constant's name
---  in the current entity scope (issue #74). The constant's value is not checked
---  and the name gets no frame slot in Pascal.Checks.Scope -- a constant is not a
---  variable -- so a reference to it in an expression is not yet resolved
---  (minimal semantic pass).
+--  constant_definition ::= identifier '=' constant. Binds the name to the
+--  constant's value in the current scope (issue #103), so a use of it in an
+--  expression resolves and generates a literal rather than a load. Nothing is
+--  allocated: a constant is not storage.
+--
+--  Also recorded in the entity model as a "constant" (issue #74), and in the
+--  frame scope's declarations so a use can record a cross reference.
+--
+--  A constant whose value could not be evaluated -- a string, for now -- is
+--  still declared, so that a use of it reports nothing worse than the missing
+--  value it actually has. Redeclaring a name already bound in this scope is an
+--  error, as for a variable.
 
 feature
 
    After_Identifier (Name : String)
-      local
-         Ignore : Aquarius.Entities.Declaration
       do
-         Ignore := Record_Declaration (Current, Name, "constant")
+         Nm := Name
       end
+
+   After_Constant (Child : Pascal.Checks.Constant)
+      do
+         Value := Child.Value
+         Have_Value := Child.Is_Known
+      end
+
+   After_Node
+      local
+         Decl : Aquarius.Entities.Declaration
+      do
+         if attached Nm as N then
+            if Current_Frame_Scope.Is_Declared_Here (N) then
+               Error ("duplicate declaration: " & N)
+            else
+               if Have_Value then
+                  Current_Frame_Scope.Declare_Constant (N, Value)
+               end
+               Decl := Record_Declaration (Current, N, "constant")
+               Current_Frame_Scope.Add_Declaration (Decl)
+            end
+         end
+      end
+
+feature { None }
+
+   Nm         : detachable String
+   Value      : Integer
+   Have_Value : Boolean
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
@@ -28,6 +28,10 @@ feature
             Offset := Bound.Offset
             Is_Argument := Bound.Is_Argument
             By_Reference := Bound.By_Reference
+            if Bound.Is_Constant then
+               --  The loop assigns to its control variable
+               Error ("cannot use a constant as a loop variable: " & N)
+            end
             --  The for-loop control variable is written by the loop.
             Refer (Current, "write", Current_Frame_Scope.Lookup_Declaration (N))
          else

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -89,6 +89,16 @@ feature  --  declaring
          Bindings.Append (B)
       end
 
+   Declare_Constant (Name : String; Value : Integer)
+      --  Bind Name in THIS scope to a value (issue #103). Nothing is allocated:
+      --  a constant is not storage, so it takes no slot in either index space.
+      local
+         B : Pascal.Checks.Binding
+      do
+         create B.Make_Constant (Name, Value)
+         Bindings.Append (B)
+      end
+
    Add_Declaration (Declaration : Aquarius.Entities.Declaration)
       do
          Declarations.Append (Declaration)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -21,6 +21,12 @@ feature
    By_Reference : Boolean
       --  A 'var' parameter: the argument holds an address, not a value
 
+   Is_Constant : Boolean
+
+   Value : Integer
+      --  The constant's value, when Is_Constant: the code stage emits it as a
+      --  literal, since a constant has no storage to load from (issue #103)
+
    Is_Target : Boolean
 
    Set_Target
@@ -43,6 +49,11 @@ feature
                Offset := Bound.Offset
                Is_Argument := Bound.Is_Argument
                By_Reference := Bound.By_Reference
+               Is_Constant := Bound.Is_Constant
+               Value := Bound.Value
+               if Is_Constant and then Is_Target then
+                  Error ("cannot assign to a constant: " & N)
+               end
                --  Record a cross reference to the declared variable: a write
                --  when this access is an assignment target (flagged by the
                --  enclosing assignment_statement), otherwise a read.

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
@@ -25,9 +25,14 @@ feature
       local
          L : Ast.Expression.Local_Variable
          A : Ast.Expression.Argument
+         K : Ast.Expression.Literal
       do
          if attached Checks as C then
-            if C.By_Reference then
+            if C.Is_Constant then
+               --  A constant has no storage: emit its value (issue #103)
+               create K.Make_Integer (Void, Current, C.Value)
+               Set_Expr (K)
+            elsif C.By_Reference then
                --  A 'var' parameter holds an address: reading it needs a
                --  dereference and writing it an indirect store, and neither
                --  Ast.Expression.Argument nor Tagatha's Push_Argument /

--- a/share/aquarius/tests/pascal/test_constant_errors.pas
+++ b/share/aquarius/tests/pascal/test_constant_errors.pas
@@ -1,0 +1,27 @@
+{ Constants, the error cases, issue #103. Expect exactly THREE errors:
+
+     duplicate declaration: Max          -- redeclared in the same scope
+     cannot assign to a constant: Max    -- a constant is not storage
+     cannot use a constant as a loop variable: Max
+
+  A constant shares its scope with the block's variables, so redeclaring the name
+  is an error just as it is for two variables -- while a constant declared in an
+  inner block may shadow an outer one, as test_constants.pas shows.
+
+  Check with: bin/aquarius --check test_constant_errors.pas }
+
+program Test_Constant_Errors;
+
+const
+   Max = 10;
+   Max = 20;              { error: same scope }
+
+var
+   total : integer;
+
+begin
+   total := Max;          { fine }
+   Max := 1;              { error: not storage }
+   for Max := 1 to 5 do   { error: the loop assigns to it }
+      total := total + 1
+end.

--- a/share/aquarius/tests/pascal/test_constants.pas
+++ b/share/aquarius/tests/pascal/test_constants.pas
@@ -1,0 +1,49 @@
+{ Constant identifiers, issue #103. Expect NO errors.
+
+  A constant binds to a value rather than to storage, so a use of one generates
+  the literal and takes no frame slot. Constants live in the scope they are
+  declared in, like any other name, so one declared in a procedure is invisible
+  outside it and may shadow an outer one.
+
+  Check with: bin/aquarius --check test_constants.pas }
+
+program Test_Constants;
+
+const
+   Max = 10;
+   Min = -4;              { a signed constant }
+   Plus_Signed = +7;
+   Limit = Max;           { defined from an earlier constant }
+   Neg_Limit = -Max;      { and negated }
+   Star = '*';            { a character constant is its code point }
+   Letter = 'K';
+
+var
+   i, total : integer;
+   c : char;
+
+procedure Uses_Outer_Constants;
+begin
+   total := Max + Limit
+end;
+
+procedure Has_Its_Own;
+   const
+      Max = 99;           { shadows the program's Max }
+   var
+      local_total : integer;
+begin
+   local_total := Max;    { 99, not 10 }
+   total := total + local_total
+end;
+
+begin
+   total := Max;
+   total := total + Min + Plus_Signed + Limit + Neg_Limit;
+   c := Star;
+   c := Letter;
+   for i := 1 to Max do   { a constant as a loop bound }
+      total := total + i;
+   Uses_Outer_Constants;
+   Has_Its_Own
+end.


### PR DESCRIPTION
A constant's name was recorded in the entity model and bound to nothing, so every use of one was reported as an undeclared variable.

A constant binds to a value rather than to storage, which is the whole design: Binding gains Make_Constant with Is_Constant and Value, takes no slot in either index space, and a use of it generates Ast.Expression.Literal instead of a load. That is also why it works where a value is needed before the program runs, as in array [1 .. maxpgm].  Because the binding lives in the scope it was declared in, a constant declared inside a procedure is correctly invisible outside it and may shadow an outer one -- inherited from #81 with no extra work.

Pascal.Checks.Constant evaluates the production: a signed or unsigned integer literal, a character literal, or a reference to an earlier constant with or without a sign.  Assigning to a constant, and using one as a loop variable, are now errors rather than silently generating a store to whatever the offset happened to be.

Character literals were meant to be out of scope, but they are values rather than text and the sample programs lean on them heavily -- starsym = '*', entsym = 'E' -- so they are read as their code point.  They were 29 of startrek's 97.

A real literal is explicitly refused rather than truncated.  "3.14" fed to String.To_Integer returns a quietly wrong answer, so Looks_Real tests for a decimal point or an exponent and leaves the constant unvalued until #87 and #88. A string of more than one character is left unvalued for the same reason: there is nowhere yet to put the text.

Undeclared-variable reports: startrek 337 -> 240, basics 369 -> 300, prettyprint 481 -> 458, pl0 216 -> 208, so 197 fewer.

Verified in the emitted code, not only semantically, which is how a real bug turned up: Value.Convert_From (Ch.UTF_32_Code) on an ATTRIBUTE silently does nothing.  The intrinsic is replace-current, which swaps and pops the stack copy and never writes the field back, so every character constant generated MOV #0 while the semantic stage looked perfect.  Converting into a local and assigning fixes it.  Every use in the standard library happens to be a local, which is why this had not been seen before.

test_constants.pas covers signed constants, one defined from another, negation of a reference, character constants, a constant as a loop bound, and a constant shadowed inside a procedure; test_constant_errors.pas pins the three errors.  The generated frame reserves words for the variables only -- four words for four variables, nothing for the eight constants.