### PR TITLE
feat: check calls against their parameter lists (#105)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter.aqua
@@ -1,0 +1,33 @@
+class
+   Pascal.Checks.Actual_Parameter
+
+inherit
+   Pascal.Checks.Node
+
+--  actual_parameter ::= expression [ ':' expression [ ':' expression ] ].
+--  One argument of a call (issue #105). The optional extra expressions are the
+--  write field widths -- write (x:5:2) passes ONE argument -- so the arity is the
+--  number of actual_parameter nodes, not the number of expressions.
+--
+--  Is_Variable says whether the argument is a bare variable, which is what a var
+--  parameter requires: it takes the address of its actual, so an expression has
+--  nothing to take the address of. The flag arrives up the expression chain,
+--  since After_ handlers see direct children only.
+
+feature
+
+   Is_Variable : Boolean
+
+   After_Expression (Child : Pascal.Checks.Expression)
+      do
+         if Expressions = 0 then
+            Is_Variable := Child.Is_Variable
+         end
+         Expressions := Expressions + 1
+      end
+
+feature { None }
+
+   Expressions : Integer
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter_list.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter_list.aqua
@@ -1,0 +1,29 @@
+class
+   Pascal.Checks.Actual_Parameter_List
+
+inherit
+   Pascal.Checks.Node
+
+--  actual_parameter_list ::= '(' < actual_parameter / ',' > ')'. The argument
+--  list of a procedure statement; Count is its arity (issue #105).
+--
+--  Variable_Mask carries one bit per argument, set when that argument is a bare
+--  variable: a visitor cannot hold a reference to another plugin object
+--  (issue #107), and Integer has no bit operations (issue #109), so the flags
+--  travel as arithmetic. Node.Mask_Holds reads it back.
+
+feature
+
+   Count : Integer
+
+   Variable_Mask : Integer
+
+   After_Actual_Parameter (Child : Pascal.Checks.Actual_Parameter)
+      do
+         Count := Count + 1
+         if Child.Is_Variable then
+            Variable_Mask := Variable_Mask + Argument_Weight (Count)
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -2,7 +2,7 @@ class
    Pascal.Checks.Binding
 
 create
-   Make_Local, Make_Argument, Make_Constant
+   Make_Local, Make_Argument, Make_Constant, Make_Routine
 
 --  One name bound to one slot of the enclosing routine's frame, held by
 --  Pascal.Checks.Scope (issue #81).
@@ -48,6 +48,13 @@ feature
          Is_Constant := True
       end
 
+   Make_Routine (Bound_Name : String; Routine : Pascal.Checks.Signature)
+      do
+         Name := Bound_Name.To_Lower
+         Signature := Routine
+         Is_Routine := True
+      end
+
    Name : String
 
    Offset : Integer
@@ -57,9 +64,14 @@ feature
    Value : Integer
       --  The value of a constant; meaningless for anything else
 
+   Signature : detachable Pascal.Checks.Signature
+      --  What the routine takes, when Is_Routine; Void otherwise
+
    Is_Argument : Boolean
 
    Is_Constant : Boolean
+
+   Is_Routine : Boolean
 
    By_Reference : Boolean
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-expression.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-expression.aqua
@@ -1,0 +1,30 @@
+class
+   Pascal.Checks.Expression
+
+inherit
+   Pascal.Checks.Node
+
+--  expression ::= < simple_expression / relational_operator >. Top of the chain
+--  that carries "this expression is a bare variable" up to actual_parameter
+--  (issue #105). A comparison is not a variable, so more than one
+--  simple_expression settles it.
+
+feature
+
+   Is_Variable : Boolean
+
+   After_Simple_Expression (Child : Pascal.Checks.Simple_Expression)
+      do
+         if Parts = 0 then
+            Is_Variable := Child.Is_Variable
+         else
+            Is_Variable := False
+         end
+         Parts := Parts + 1
+      end
+
+feature { None }
+
+   Parts : Integer
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-factor.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-factor.aqua
@@ -1,0 +1,38 @@
+class
+   Pascal.Checks.Factor
+
+inherit
+   Pascal.Checks.Node
+
+--  factor ::= variable_access | unsigned_constant | set_constructor
+--           | '(' expression ')' | 'not' factor
+--
+--  First rung of the chain that carries "this expression is a bare variable"
+--  from a variable_access up to the actual_parameter that encloses it, which is
+--  what a var parameter needs to know: it takes the address of its actual, so an
+--  expression has nothing to take the address of (issue #105).
+--
+--  A class per level is unavoidable -- After_ handlers see direct children only,
+--  which is why the code stage has the same chain -- but each rung is a copy.
+--  A parenthesised expression counts: (x) is still the variable x.
+
+feature
+
+   Is_Variable : Boolean
+
+   After_Variable_Access (Child : Pascal.Checks.Variable_Access)
+      do
+         --  A call is not a variable. A component IS one: an indexed variable or
+         --  a field has an address, so Pascal allows it as a var actual, and
+         --  rejecting it reported 24 false positives in basics.pas alone
+         --  (prgm[i] passed to a var parameter). That the code stage cannot yet
+         --  take that address is issue #104, and it says so there.
+         Is_Variable := not Child.Is_Call
+      end
+
+   After_Expression (Child : Pascal.Checks.Expression)
+      do
+         Is_Variable := Child.Is_Variable
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-function_designator.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-function_designator.aqua
@@ -1,0 +1,31 @@
+class
+   Pascal.Checks.Function_Designator
+
+inherit
+   Pascal.Checks.Node
+
+--  function_designator ::= '(' < actual_parameter / ',' > ')'. The argument list
+--  of a call written in an expression: the same shape as actual_parameter_list,
+--  but it reaches the checks stage as a variable_suffix, because that is how the
+--  grammar spells a call (issue #105).
+--
+--  Which arguments are bare variables is carried as one bit per argument in
+--  Variable_Mask rather than as a list, because a visitor cannot hold a
+--  reference to another plugin object (issue #107) and Integer has no bit
+--  operations (issue #109). Node.Mask_Holds reads it back.
+
+feature
+
+   Count : Integer
+
+   Variable_Mask : Integer
+
+   After_Actual_Parameter (Child : Pascal.Checks.Actual_Parameter)
+      do
+         Count := Count + 1
+         if Child.Is_Variable then
+            Variable_Mask := Variable_Mask + Argument_Weight (Count)
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-function_heading.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-function_heading.aqua
@@ -10,6 +10,10 @@ inherit
 --  identifier is nested (inside result_type), so After_Identifier fires only
 --  for the function name. Pascal.Checks.Function_Declaration.After_Node closes
 --  the scope.
+--
+--  As for a procedure, the name is bound as a routine in the enclosing scope
+--  with a signature the parameters fill in (issue #105); this one returns a
+--  value, so a call to it is legal in an expression.
 
 feature
 
@@ -17,10 +21,13 @@ feature
       local
          Ignore     : Aquarius.Entities.Declaration
          Func_Scope : Aquarius.Entities.Scope
+         Sig        : Pascal.Checks.Signature
       do
          Ignore := Record_Declaration (Current, Name, "function")
+         Sig := Declare_Routine (Name, True, False)
          create Func_Scope.Make
          Enter_Scope (Func_Scope)
+         Current_Frame_Scope.Set_Routine (Sig)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -102,6 +102,24 @@ feature
          Current_Scope.Add_Declaration (Result)
       end
 
+   Declare_Routine (Name        : String
+                    Is_Function : Boolean
+                    Is_Variadic : Boolean) : Pascal.Checks.Signature
+      --  Bind Name as a routine in the current scope, which for a heading is the
+      --  scope ENCLOSING the routine, and return the signature now in force
+      --  (issue #105). The caller passes it to Set_Routine on the routine's own
+      --  scope after entering it.
+      --
+      --  A function rather than a procedure leaving the signature in a field:
+      --  adding an attribute to this class -- the base of every checks visitor --
+      --  corrupted the generated code (see the note in Program.Before_Node).
+      local
+         Sig : Pascal.Checks.Signature
+      do
+         create Sig.Make (Is_Function, Is_Variadic)
+         Result := Current_Frame_Scope.Declare_Routine (Name, Sig)
+      end
+
    Declare_Parameters (List         : Pascal.Checks.Identifier_List
                        By_Reference : Boolean
                        Category     : String)
@@ -130,11 +148,59 @@ feature
             else
                Ignore :=
                   Current_Frame_Scope.Declare_Argument (Name, By_Reference)
+               --  Record it in the routine's signature too, so a call can be
+               --  checked against it (issue #105)
+               if attached Current_Frame_Scope.Routine as Sig then
+                  Sig.Add_Parameter (By_Reference)
+               end
                Decl := Record_Declaration (Current, Name, Category)
                Current_Frame_Scope.Add_Declaration (Decl)
             end
             It.Next
          end
+      end
+
+   Argument_Weight (Index : Integer) : Integer
+      --  2 ** (Index - 1), the bit that stands for argument Index in an argument
+      --  mask. Zero beyond Argument_Mask_Limit, where the mask runs out.
+      local
+         At : Integer
+      do
+         if Index >= 1 and then Index <= Argument_Mask_Limit then
+            Result := 1
+            from
+               At := 1
+            until
+               At >= Index
+            loop
+               Result := Result * 2
+               At := At + 1
+            end
+         end
+      end
+
+   Mask_Holds (Mask : Integer; Index : Integer) : Boolean
+      --  Whether the bit for argument Index is set in Mask.
+      --
+      --  Arithmetic rather than bit operations because Integer has neither an
+      --  and nor a shift (issue #109), and a mask rather than a list because a
+      --  visitor cannot hold a reference to another plugin object (issue #107).
+      --  Both go away when those are fixed.
+      local
+         Weight : Integer
+      do
+         Weight := Argument_Weight (Index)
+         if Weight > 0 then
+            Result := (Mask / Weight) mod 2 = 1
+         end
+      end
+
+   Argument_Mask_Limit : Integer
+      --  Arguments past the 30th are not represented: an Integer is 32 bits and
+      --  the mask is built by doubling. No Pascal call comes close, and a call
+      --  that did would simply go unchecked rather than wrong.
+      do
+         Result := 30
       end
 
    Ensure_Builtins
@@ -153,6 +219,24 @@ feature
             Declare_Builtin ("read",     "builtin-procedure")
             Declare_Builtin ("readln",   "builtin-procedure")
          end
+      end
+
+   Declare_Builtin_Routines
+      --  Bind the standard I/O procedures as routines in the ROOT frame scope,
+      --  so a call to one resolves like a call to any other (issue #105). They
+      --  are variadic: write and writeln take any number of arguments, and each
+      --  may carry field widths, so an argument count proves nothing.
+      --
+      --  Re-declared for each program rather than once, because the root scope
+      --  is a once value that Program.Before_Node resets. The type names and the
+      --  entity-model declarations are handled separately by Ensure_Builtins.
+      local
+         Ignore : Pascal.Checks.Signature
+      do
+         Ignore := Declare_Routine ("write", False, True)
+         Ignore := Declare_Routine ("writeln", False, True)
+         Ignore := Declare_Routine ("read", False, True)
+         Ignore := Declare_Routine ("readln", False, True)
       end
 
    Declare_Builtin (Name : String; Category : String)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_heading.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_heading.aqua
@@ -10,6 +10,11 @@ inherit
 --  declarations nest inside it (issue #74). The matching Leave_Scope is done by
 --  Pascal.Checks.Procedure_Declaration.After_Node, which fires after the whole
 --  heading and block have reduced.
+--
+--  The name is also bound as a routine in the ENCLOSING scope, carrying a
+--  signature that the parameters fill in as they reduce (issue #105). Binding it
+--  outside its own scope is what lets a later call -- or a recursive one -- find
+--  it, and is why the signature outlives the scope that describes it.
 
 feature
 
@@ -17,10 +22,13 @@ feature
       local
          Ignore     : Aquarius.Entities.Declaration
          Proc_Scope : Aquarius.Entities.Scope
+         Sig        : Pascal.Checks.Signature
       do
          Ignore := Record_Declaration (Current, Name, "procedure")
+         Sig := Declare_Routine (Name, False, False)
          create Proc_Scope.Make
          Enter_Scope (Proc_Scope)
+         Current_Frame_Scope.Set_Routine (Sig)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_identifier.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_identifier.aqua
@@ -1,0 +1,11 @@
+class
+   Pascal.Checks.Procedure_Identifier
+
+inherit
+   Pascal.Checks.Node
+
+--  procedure_identifier ::= identifier. The callee name of a procedure
+--  statement; the enclosing Pascal.Checks.Procedure_Statement reads it from
+--  Concatenated_Image (issue #105).
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_statement.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_statement.aqua
@@ -1,0 +1,88 @@
+class
+   Pascal.Checks.Procedure_Statement
+
+inherit
+   Pascal.Checks.Node
+
+--  procedure_statement ::= procedure_identifier [ actual_parameter_list ].
+--  Resolves the callee and checks the argument count against its signature
+--  (issue #105). Nothing checked a call before this: calling an undeclared
+--  procedure, or passing any number of arguments to a known one, was accepted
+--  silently.
+--
+--  A function may be called as a statement in real Pascal code, discarding the
+--  result, so that is not treated as an error here.
+
+feature
+
+   After_Procedure_Identifier (Child : Pascal.Checks.Procedure_Identifier)
+      do
+         Nm := Child.Concatenated_Image
+      end
+
+   After_Actual_Parameter_List (Child : Pascal.Checks.Actual_Parameter_List)
+      do
+         Given_Arguments := Child.Count
+         Argument_Variables := Child.Variable_Mask
+      end
+
+   After_Node
+      local
+         B : detachable Pascal.Checks.Binding
+      do
+         if attached Nm as N then
+            B := Current_Frame_Scope.Lookup (N)
+            if attached B as Bound then
+               if Bound.Is_Routine then
+                  if attached Bound.Signature as Sig then
+                     if not Sig.Is_Variadic
+                       and then Given_Arguments /= Sig.Argument_Count
+                     then
+                        Error ("wrong number of arguments for " & N
+                               & ": expected " & Sig.Argument_Count.To_String
+                               & ", found " & Given_Arguments.To_String)
+                     else
+                        Check_Var_Arguments (N, Sig)
+                     end
+                  end
+                  Refer (Current, "call",
+                         Current_Frame_Scope.Lookup_Declaration (N))
+               else
+                  Error ("not a procedure: " & N)
+               end
+            else
+               Error ("undeclared procedure: " & N)
+            end
+         end
+      end
+
+feature { None }
+
+   Nm                 : detachable String
+   Given_Arguments    : Integer
+   Argument_Variables : Integer
+      --  One bit per argument, set when it is a bare variable (issue #107)
+
+   Check_Var_Arguments (Name : String; Sig : Pascal.Checks.Signature)
+      --  A var parameter is passed by address, so its actual has to be something
+      --  with an address. This is checkable without any type system, and it
+      --  catches a mistake the compiler would otherwise have no way to notice.
+      local
+         Index : Integer
+      do
+         from
+            Index := 1
+         until
+            Index > Given_Arguments
+         loop
+            if Sig.Parameter_By_Reference (Index) then
+               if not Mask_Holds (Argument_Variables, Index) then
+                  Error ("argument " & Index.To_String & " of " & Name
+                         & " is a var parameter, so it needs a variable")
+               end
+            end
+            Index := Index + 1
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
@@ -25,6 +25,7 @@ feature
          --  last program compiled in this session.
          Scope.Reset
          Context.Set_Current_Frame_Scope (Scope)
+         Declare_Builtin_Routines
          create Program_Scope.Make
          Enter_Scope (Program_Scope)
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -49,6 +49,16 @@ feature
          Parent := Enclosing
       end
 
+   Routine : detachable Pascal.Checks.Signature
+      --  The signature of the routine this scope belongs to, so that parameters
+      --  reducing into the scope can be added to it (issue #105). Void for the
+      --  root and the program scope, which are not routines.
+
+   Set_Routine (Signature : Pascal.Checks.Signature)
+      do
+         Routine := Signature
+      end
+
    Reset
       --  Return the scope to its initial state. The shared root scope is a once
       --  value and the plugin reuses one VM across files, so the root has to be
@@ -87,6 +97,33 @@ feature  --  declaring
          Result := Allocated_Arguments
          create B.Make_Argument (Name, Result, By_Reference)
          Bindings.Append (B)
+      end
+
+   Declare_Routine (Name : String; Routine : Pascal.Checks.Signature)
+      : Pascal.Checks.Signature
+      --  Bind Name in THIS scope to a routine, and return the signature that is
+      --  now in force (issue #105).
+      --
+      --  If the name is already bound to a routine here, the existing signature
+      --  is kept and returned: that is a forward declaration being completed.
+      --  Pascal gives the parameters on the FORWARD heading and repeats only the
+      --  name on the body, so the first signature is the complete one.
+      local
+         B        : Pascal.Checks.Binding
+         Existing : detachable Pascal.Checks.Binding
+      do
+         Existing := Find (Name)
+         Result := Routine
+         if attached Existing as Already then
+            if Already.Is_Routine then
+               if attached Already.Signature as Known then
+                  Result := Known
+               end
+            end
+         else
+            create B.Make_Routine (Name, Routine)
+            Bindings.Append (B)
+         end
       end
 
    Declare_Constant (Name : String; Value : Integer)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-sign.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-sign.aqua
@@ -1,0 +1,11 @@
+class
+   Pascal.Checks.Sign
+
+inherit
+   Pascal.Checks.Node
+
+--  sign ::= '+' | '-'. Presence alone matters: a signed expression is not a bare
+--  variable, so it cannot be passed to a var parameter (issue #105).
+--  Pascal.Checks.Simple_Expression reads it by After_Sign firing.
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-signature.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-signature.aqua
@@ -1,0 +1,73 @@
+class
+   Pascal.Checks.Signature
+
+create
+   Make
+
+--  What a call has to agree with: how many parameters a routine takes, which of
+--  them are passed by reference, and whether it returns a value (issue #105).
+--
+--  A signature outlives the scope it describes. A routine's own scope -- which
+--  holds its parameter bindings and knows how many there are -- is popped when
+--  its declaration ends, so a call written later would have nothing to check
+--  against. The signature is therefore declared in the ENCLOSING scope, as part
+--  of the routine's binding, and filled in as the parameters reduce.
+--
+--  Variadic covers the standard I/O procedures: write and writeln take any
+--  number of arguments, so counting them proves nothing.
+
+feature
+
+   Make (Returns_A_Value : Boolean; Any_Argument_Count : Boolean)
+      do
+         create By_Reference_Flags
+         Argument_Count := 0
+         Is_Function := Returns_A_Value
+         Is_Variadic := Any_Argument_Count
+      end
+
+   Argument_Count : Integer
+
+   Is_Function : Boolean
+
+   Is_Variadic : Boolean
+
+   Add_Parameter (By_Reference : Boolean)
+      do
+         if By_Reference then
+            By_Reference_Flags.Append (1)
+         else
+            By_Reference_Flags.Append (0)
+         end
+         Argument_Count := Argument_Count + 1
+      end
+
+   Parameter_By_Reference (Index : Integer) : Boolean
+      --  True if parameter Index (1-based) is a var parameter. False for an
+      --  index out of range, which the arity check reports separately.
+      --
+      --  The flags are held as 1 and 0 rather than as Booleans: a
+      --  Linked_List [Boolean] corrupts the VM (see the class comment).
+      local
+         It : Aqua.Containers.Linked_List_Iterator [Integer]
+         At : Integer
+      do
+         from
+            It := By_Reference_Flags.New_Cursor
+            At := 0
+         until
+            It.After
+         loop
+            At := At + 1
+            if At = Index then
+               Result := It.Element = 1
+            end
+            It.Next
+         end
+      end
+
+feature { None }
+
+   By_Reference_Flags : Aqua.Containers.Linked_List [Integer]
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-simple_expression.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-simple_expression.aqua
@@ -1,0 +1,35 @@
+class
+   Pascal.Checks.Simple_Expression
+
+inherit
+   Pascal.Checks.Node
+
+--  simple_expression ::= [ sign ] < term / adding_operator >. A bare variable
+--  only if it is one term with no sign and no operator: -x and x + 1 are not
+--  variables (issue #105).
+
+feature
+
+   Is_Variable : Boolean
+
+   After_Sign (Child : Pascal.Checks.Sign)
+      do
+         Signed := True
+      end
+
+   After_Term (Child : Pascal.Checks.Term)
+      do
+         if Terms = 0 and then not Signed then
+            Is_Variable := Child.Is_Variable
+         else
+            Is_Variable := False
+         end
+         Terms := Terms + 1
+      end
+
+feature { None }
+
+   Terms  : Integer
+   Signed : Boolean
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-term.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-term.aqua
@@ -1,0 +1,28 @@
+class
+   Pascal.Checks.Term
+
+inherit
+   Pascal.Checks.Node
+
+--  term ::= < factor / multiplying_operator >. A bare variable only if it is one
+--  factor and no operator: x is a variable, x * 2 is not (issue #105).
+
+feature
+
+   Is_Variable : Boolean
+
+   After_Factor (Child : Pascal.Checks.Factor)
+      do
+         if Factors = 0 then
+            Is_Variable := Child.Is_Variable
+         else
+            Is_Variable := False
+         end
+         Factors := Factors + 1
+      end
+
+feature { None }
+
+   Factors : Integer
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -9,8 +9,17 @@ inherit
 --  whether that offset indexes the routine's arguments or its locals -- separate
 --  spaces in Tagatha, so the code stage has to know which (issue #82).
 --  Pascal.Generate.Variable_Access for the same node receives this object by
---  type-injection (issue #66) and reads the fields directly. An undeclared name
---  is a semantic error. Scalars only.
+--  type-injection (issue #66) and reads the fields directly.
+--
+--  A call is written this way too: a function_designator suffix makes this a call
+--  rather than a load (issue #105), which is why an unknown standard function
+--  used to be reported as an undeclared VARIABLE. When the name resolves to a
+--  routine, the argument count is checked against its signature and Is_Call is
+--  set, so that the code stage does not treat the name as storage -- it has no
+--  offset, and emitting a load for it produced a store to local slot 0.
+--
+--  Structured access (a subscript, a field, a pointer dereference) is still
+--  unsupported, but is now reported rather than silently ignored: issue #104.
 
 feature
 
@@ -27,6 +36,14 @@ feature
       --  The constant's value, when Is_Constant: the code stage emits it as a
       --  literal, since a constant has no storage to load from (issue #103)
 
+   Is_Call : Boolean
+      --  The name is a routine; the code stage must not load it (issue #105)
+
+   Is_Component : Boolean
+      --  A subscript, field or dereference was written. The code stage must not
+      --  emit a plain load of the base variable, which is what it did while the
+      --  suffix was ignored altogether (issue #104)
+
    Is_Target : Boolean
 
    Set_Target
@@ -39,6 +56,17 @@ feature
          Nm := Child.Concatenated_Image
       end
 
+   After_Variable_Suffix (Child : Pascal.Checks.Variable_Suffix)
+      do
+         if Child.Is_Call then
+            Has_Argument_List := True
+            Given_Arguments := Child.Argument_Count
+            Argument_Variables := Child.Variable_Mask
+         else
+            Is_Component := True
+         end
+      end
+
    After_Node
       local
          B : detachable Pascal.Checks.Binding
@@ -46,13 +74,23 @@ feature
          if attached Nm as N then
             B := Current_Frame_Scope.Lookup (N)
             if attached B as Bound then
-               Offset := Bound.Offset
-               Is_Argument := Bound.Is_Argument
-               By_Reference := Bound.By_Reference
-               Is_Constant := Bound.Is_Constant
-               Value := Bound.Value
-               if Is_Constant and then Is_Target then
-                  Error ("cannot assign to a constant: " & N)
+               if Bound.Is_Routine then
+                  Check_Call (N, Bound)
+               else
+                  Offset := Bound.Offset
+                  Is_Argument := Bound.Is_Argument
+                  By_Reference := Bound.By_Reference
+                  Is_Constant := Bound.Is_Constant
+                  Value := Bound.Value
+                  if Is_Constant and then Is_Target then
+                     Error ("cannot assign to a constant: " & N)
+                  end
+                  if Has_Argument_List then
+                     Error ("not a routine, so it cannot be called: " & N)
+                  end
+                  if Is_Component then
+                     Error ("not supported yet: a component of " & N)
+                  end
                end
                --  Record a cross reference to the declared variable: a write
                --  when this access is an assignment target (flagged by the
@@ -63,7 +101,11 @@ feature
                   Refer (Current, "read", Current_Frame_Scope.Lookup_Declaration (N))
                end
             else
-               Error ("undeclared variable: " & N)
+               if Has_Argument_List then
+                  Error ("undeclared routine: " & N)
+               else
+                  Error ("undeclared variable: " & N)
+               end
             end
          end
       end
@@ -71,5 +113,58 @@ feature
 feature { None }
 
    Nm : detachable String
+
+   Has_Argument_List  : Boolean
+   Given_Arguments    : Integer
+   Argument_Variables : Integer
+      --  One bit per argument, set when it is a bare variable. A mask rather
+      --  than the suffix object, because a visitor holding a reference to
+      --  another plugin object corrupts generated code (issue #107).
+
+   Check_Call (Name : String; Bound : Pascal.Checks.Binding)
+      --  The name is a routine. Report what a call to it cannot do, and check
+      --  the argument count against the signature.
+      do
+         Is_Call := True
+         if Is_Target then
+            --  Assigning to a function name sets its result, which needs the
+            --  result slot: issue #84.
+            Error ("not supported yet: assignment to the result of " & Name)
+         elsif attached Bound.Signature as Sig then
+            if not Sig.Is_Function then
+               Error ("a procedure has no value, so it cannot be used here: "
+                      & Name)
+            elsif not Sig.Is_Variadic
+              and then Given_Arguments /= Sig.Argument_Count
+            then
+               Error ("wrong number of arguments for " & Name
+                      & ": expected " & Sig.Argument_Count.To_String
+                      & ", found " & Given_Arguments.To_String)
+            else
+               Check_Var_Arguments (Name, Sig)
+            end
+         end
+      end
+
+   Check_Var_Arguments (Name : String; Sig : Pascal.Checks.Signature)
+      --  As Pascal.Checks.Procedure_Statement does: a var parameter is passed by
+      --  address, so its actual has to be a variable.
+      local
+         Index : Integer
+      do
+         from
+            Index := 1
+         until
+            Index > Given_Arguments
+         loop
+            if Sig.Parameter_By_Reference (Index) then
+               if not Mask_Holds (Argument_Variables, Index) then
+                  Error ("argument " & Index.To_String & " of " & Name
+                         & " is a var parameter, so it needs a variable")
+               end
+            end
+            Index := Index + 1
+         end
+      end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
@@ -1,0 +1,36 @@
+class
+   Pascal.Checks.Variable_Suffix
+
+inherit
+   Pascal.Checks.Node
+
+--  variable_suffix ::= indexed_variable | field_designator | identified_variable
+--                    | function_designator
+--
+--  Only the call form is understood (issue #105): a function_designator makes
+--  the enclosing variable_access a call rather than a load, and carries the
+--  number of arguments and which of them are bare variables. The other three --
+--  subscript, field selection and pointer dereference -- are structured access,
+--  issue #104, and are reported by variable_access as unsupported rather than
+--  silently ignored, which is what used to happen.
+--
+--  The argument information is copied out as values rather than kept as a
+--  reference to the child: a visitor holding a reference to another plugin
+--  object corrupts the generated code (issue #107).
+
+feature
+
+   Is_Call : Boolean
+
+   Argument_Count : Integer
+
+   Variable_Mask : Integer
+
+   After_Function_Designator (Child : Pascal.Checks.Function_Designator)
+      do
+         Is_Call := True
+         Argument_Count := Child.Count
+         Variable_Mask := Child.Variable_Mask
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-generate-variable_access.aqua
@@ -28,7 +28,18 @@ feature
          K : Ast.Expression.Literal
       do
          if attached Checks as C then
-            if C.Is_Constant then
+            if C.Is_Call then
+               --  A routine name, not storage. Lowering a call written in an
+               --  expression needs the argument expressions from the suffix and
+               --  an Ast.Expression.Call; until then, refuse. Emitting a load
+               --  here stored to local slot 0 (issue #105).
+               Error ("not implemented: calling a routine in an expression")
+            elsif C.Is_Component then
+               --  A subscript, field or dereference. Loading the base variable
+               --  and discarding the suffix is what used to happen, silently
+               --  (issue #104).
+               Error ("not implemented: a component of a structured variable")
+            elsif C.Is_Constant then
                --  A constant has no storage: emit its value (issue #103)
                create K.Make_Integer (Void, Current, C.Value)
                Set_Expr (K)

--- a/share/aquarius/tests/pascal/test_call_errors.pas
+++ b/share/aquarius/tests/pascal/test_call_errors.pas
@@ -1,0 +1,49 @@
+{ Calls, the error cases, issue #105. Expect exactly SEVEN errors:
+
+     wrong number of arguments for One_Argument: expected 1, found 0
+     wrong number of arguments for One_Argument: expected 1, found 2
+     undeclared procedure: Nosuch
+     wrong number of arguments for Add: expected 2, found 1
+     a procedure has no value, so it cannot be used here: No_Arguments
+     argument 1 of By_Ref is a var parameter, so it needs a variable
+     argument 1 of By_Ref is a var parameter, so it needs a variable
+
+  Every one of these was accepted silently before: a call was never compared
+  with the routine it called.
+
+  Check with: bin/aquarius --check test_call_errors.pas }
+
+program Test_Call_Errors;
+
+var
+   g : integer;
+
+procedure No_Arguments;
+begin
+   g := 0
+end;
+
+procedure One_Argument(x : integer);
+begin
+   g := x
+end;
+
+procedure By_Ref(var total : integer);
+begin
+   total := 0
+end;
+
+function Add(a, b : integer) : integer;
+begin
+   writeln(a + b)
+end;
+
+begin
+   One_Argument;           { too few }
+   One_Argument(1, 2);     { too many }
+   Nosuch(1);              { no such routine }
+   g := Add(1);            { too few, in an expression }
+   g := No_Arguments;      { a procedure has no value }
+   By_Ref(42);             { a literal has no address }
+   By_Ref(g + 1)           { nor has an expression }
+end.

--- a/share/aquarius/tests/pascal/test_calls.pas
+++ b/share/aquarius/tests/pascal/test_calls.pas
@@ -1,0 +1,55 @@
+{ Calls checked against their parameter lists, issue #105. Expect NO errors.
+
+  A call is resolved against the callee's signature, which is recorded on the
+  routine's binding in the ENCLOSING scope -- the routine's own scope, which
+  knows its parameters, is gone by the time a call is written.
+
+  Check with: bin/aquarius --check test_calls.pas }
+
+program Test_Calls;
+
+var
+   g, h : integer;
+
+procedure No_Arguments;
+begin
+   g := 0
+end;
+
+procedure One_Argument(x : integer);
+begin
+   g := x
+end;
+
+procedure Several(a, b : integer; c : integer);
+begin
+   g := a + b + c
+end;
+
+procedure By_Ref(var total : integer; increment : integer);
+begin
+   total := total + increment
+end;
+
+function Add(a, b : integer) : integer;
+begin
+   writeln(a + b)
+end;
+
+procedure Calls_Its_Sibling(n : integer);
+begin
+   One_Argument(n);        { a call from inside another routine }
+   By_Ref(g, n)            { a global is a variable, so it may be passed by ref }
+end;
+
+begin
+   No_Arguments;
+   One_Argument(1);
+   Several(1, 2, 3);
+   By_Ref(g, 1);
+   By_Ref(h, g + 1);       { only the first parameter is var }
+   Calls_Its_Sibling(2);
+   g := Add(1, 2);
+   writeln(g, h, g + h);   { write and writeln take any number of arguments }
+   writeln(g:5)            { a field width is part of one argument, not a second }
+end.


### PR DESCRIPTION
A call was never compared with the routine it called.  Calling an undeclared procedure, passing any number of arguments to a known one, or handing a literal to a var parameter were all accepted in silence.

The obstacle was that a signature does not survive: a routine's own scope, which knows its parameters, is popped when its declaration ends, so a call written later has nothing to check against.  Routines are therefore bound in the ENCLOSING scope, carrying a Pascal.Checks.Signature that the parameters fill in as they reduce.  Binding gains a routine kind alongside local, argument and constant, so one lookup mechanism now answers for every kind of name -- which is also what lets a recursive call resolve.  A repeated routine name keeps the first signature rather than reporting a duplicate: that is a forward declaration being completed, and Pascal puts the parameters on the forward heading.

A call in an expression is not a name lookup at all.  The grammar spells it as variable_access with a function_designator suffix, which is why an unknown standard function was reported as an undeclared VARIABLE, and why variable_access now has to understand suffixes.  Structured suffixes -- a subscript, a field, a dereference -- are reported as unsupported rather than ignored, which is what used to happen while the code stage generated a plain load of the base variable.

Checked: arity, against a variadic flag for write and writeln, whose arguments carry field widths that are not separate arguments; an undeclared callee; a procedure used where a value is wanted; and that the actual for a var parameter is a variable, since it is passed by address and an expression has no address. Type compatibility waits for #88.

Two constraints from other bugs shaped the code, both marked where they bite. A visitor cannot hold a reference to another plugin object -- doing so silently corrupts the generated code (#107) -- so which arguments are variables travels as one bit per argument in an integer, and the signature is returned from a function rather than parked in a field.  Integer has no bit operations (#109), so the mask is built and read with multiplication, division and mod.  Both go away when those issues are fixed.

An indexed variable counts as a variable for the var parameter rule, as Pascal requires.  Excluding components first reported 24 false positives in basics.pas, all of them prgm[i] passed by reference.  That the code stage cannot yet take that address is #104.

Sample programs report no wrong arity and no bad var arguments -- these are published programs, so that is the expected result and a check on the checker. Newly visible instead: 137 structured accesses in startrek, 234 in basics, and the function-result assignments of #84, all previously silent.

test_calls.pas covers a call with no arguments, several arguments, a var parameter, a call from inside another routine, a function call in an expression, and the variadic forms; test_call_errors.pas pins the seven errors.  Codegen was verified on every fixture that emits code, and the probes that first exposed #107 now generate correctly.