### PR TITLE
feat: a minimal type system in Pascal.Checks (#88)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter.aqua
@@ -18,10 +18,16 @@ feature
 
    Is_Variable : Boolean
 
+   Ty : Integer
+      --  The argument's type (issue #88), taken from the same first expression
+      --  as Is_Variable: the field widths after it describe how to print the
+      --  argument, not what it is.
+
    After_Expression (Child : Pascal.Checks.Expression)
       do
          if Expressions = 0 then
             Is_Variable := Child.Is_Variable
+            Ty := Child.Ty
          end
          Expressions := Expressions + 1
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter_list.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter_list.aqua
@@ -11,6 +11,11 @@ inherit
 --  variable: a visitor cannot hold a reference to another plugin object
 --  (issue #107), and Integer has no bit operations (issue #109), so the flags
 --  travel as arithmetic. Node.Mask_Holds reads it back.
+--
+--  Type_Mask carries the type of each argument the same way, three bits apiece
+--  (issue #88). It was a Linked_List [Integer] first, which reads far better,
+--  but that attribute on this class faults the VM part way through a large
+--  program (issue #120). Pascal.Checks.Types.Packed_Type reads it back.
 
 feature
 
@@ -18,12 +23,17 @@ feature
 
    Variable_Mask : Integer
 
+   Type_Mask : Integer
+
    After_Actual_Parameter (Child : Pascal.Checks.Actual_Parameter)
+      local
+         T : Pascal.Checks.Types
       do
          Count := Count + 1
          if Child.Is_Variable then
             Variable_Mask := Variable_Mask + Argument_Weight (Count)
          end
+         Type_Mask := Type_Mask + Child.Ty * T.Type_Weight (Count)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-adding_operator.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-adding_operator.aqua
@@ -1,0 +1,37 @@
+class
+   Pascal.Checks.Adding_Operator
+
+inherit
+   Pascal.Checks.Node
+
+--  adding_operator ::= '+' | '-' | 'or'
+--
+--  Classifies the token into the typing rule its enclosing simple_expression
+--  must apply (issue #88): the two arithmetic signs take numbers, 'or' takes
+--  booleans. See Pascal.Checks.Multiplying_Operator, which does the same for its
+--  five tokens and carries the fuller note.
+
+feature
+
+   Kind : Integer
+
+   After_Node
+      local
+         T : Pascal.Checks.Types
+         S : String
+      do
+         --  Concatenated_Image, not Standard_Text: on this node the standard
+         --  text comes back empty for the keyword alternative, which silently
+         --  stopped 'or', 'div' and 'mod' from being classified at all.
+         S := Concatenated_Image
+         S := S.To_Lower
+         if S.Equal ("+") or else S.Equal ("-") then
+            Kind := T.Arithmetic_Op
+         elsif S.Equal ("or") then
+            Kind := T.Boolean_Op
+         else
+            Kind := T.No_Op
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-assignment_statement.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-assignment_statement.aqua
@@ -9,6 +9,14 @@ inherit
 --  cross reference it records is classified as a write rather than a read. The
 --  Before hook fires before the child subtree (and its After_Node, where the
 --  reference is recorded) runs.
+--
+--  That is the one piece of information in this plugin that flows DOWNWARD.
+--  Everything else flows up, which is why the type check waits for After_Node
+--  (issue #88): the target's type arrives when the variable_access reduces and
+--  the source's when the expression does, and only then are both in hand.
+--
+--  Both are copied out as Integer codes rather than the child visitors being
+--  kept, which is what #107 warns about and is unnecessary here.
 
 feature
 
@@ -16,5 +24,36 @@ feature
       do
          Child.Set_Target
       end
+
+   After_Variable_Access (Child : Pascal.Checks.Variable_Access)
+      do
+         Target_Type := Child.Ty
+      end
+
+   After_Expression (Child : Pascal.Checks.Expression)
+      do
+         Source_Type := Child.Ty
+      end
+
+   After_Node
+      local
+         T      : Pascal.Checks.Types
+         Target : Integer
+         Source : Integer
+      do
+         Target := Check_Known (Target_Type, "an assignment target")
+         Source := Check_Known (Source_Type, "an assigned value")
+         if not T.Assignable (Target, Source) then
+            --  Integer to real is Pascal's one implicit widening; the other
+            --  direction is what round and trunc are for.
+            Error ("cannot assign " & T.Name (Source) & " to "
+                   & T.Name (Target))
+         end
+      end
+
+feature { None }
+
+   Target_Type : Integer
+   Source_Type : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -2,7 +2,7 @@ class
    Pascal.Checks.Binding
 
 create
-   Make_Local, Make_Argument, Make_Constant, Make_Routine
+   Make_Local, Make_Argument, Make_Constant, Make_Routine, Make_Type
 
 --  One name bound to one slot of the enclosing routine's frame, held by
 --  Pascal.Checks.Scope (issue #81).
@@ -22,30 +22,42 @@ create
 --  Name is stored lower-cased, because Pascal is case-insensitive; compare it
 --  with String.Equal rather than '=', which is reference equality inside a
 --  generic in the Aqua VM (issue #60).
+--
+--  A type binding is the fifth kind (issue #88). The four built-in type names
+--  live in the same scope tree as the variables, so that resolving 'integer' in
+--  a type_denoter is the same lookup as resolving a variable name, and so that
+--  a user-defined alias can shadow one in an inner block. Its Ty is the type it
+--  NAMES; every other kind's Ty is the type it HAS.
 
 feature
 
-   Make_Local (Bound_Name : String; Frame_Slot : Integer)
+   Make_Local (Bound_Name : String; Frame_Slot : Integer; Type_Code : Integer)
       do
          Name := Bound_Name.To_Lower
          Offset := Frame_Slot
+         Ty := Type_Code
       end
 
    Make_Argument (Bound_Name           : String
                   Argument_Index       : Integer
-                  Passed_By_Reference  : Boolean)
+                  Passed_By_Reference  : Boolean
+                  Type_Code            : Integer)
       do
          Name := Bound_Name.To_Lower
          Offset := Argument_Index
          Is_Argument := True
          By_Reference := Passed_By_Reference
+         Ty := Type_Code
       end
 
-   Make_Constant (Bound_Name : String; Constant_Value : Integer)
+   Make_Constant (Bound_Name : String
+                  Constant_Value : Integer
+                  Type_Code : Integer)
       do
          Name := Bound_Name.To_Lower
          Value := Constant_Value
          Is_Constant := True
+         Ty := Type_Code
       end
 
    Make_Routine (Bound_Name : String; Routine : Pascal.Checks.Signature)
@@ -53,6 +65,13 @@ feature
          Name := Bound_Name.To_Lower
          Signature := Routine
          Is_Routine := True
+      end
+
+   Make_Type (Bound_Name : String; Type_Code : Integer)
+      do
+         Name := Bound_Name.To_Lower
+         Ty := Type_Code
+         Is_Type := True
       end
 
    Name : String
@@ -64,6 +83,11 @@ feature
    Value : Integer
       --  The value of a constant; meaningless for anything else
 
+   Ty : Integer
+      --  The Pascal.Checks.Types code of the variable, argument or constant;
+      --  for a type binding, the type the name stands for. A routine's result
+      --  type is on its Signature instead, since only a call has one.
+
    Signature : detachable Pascal.Checks.Signature
       --  What the routine takes, when Is_Routine; Void otherwise
 
@@ -72,6 +96,8 @@ feature
    Is_Constant : Boolean
 
    Is_Routine : Boolean
+
+   Is_Type : Boolean
 
    By_Reference : Boolean
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-constant.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-constant.aqua
@@ -16,12 +16,15 @@ inherit
 --  point -- Pascal programs use these as symbols, 'K' for a klingon and so on),
 --  and a reference to an earlier constant, with or without a sign.
 --
---  NOT handled, deliberately: a real literal, which needs Ast.Expression's real
---  literal and a place to keep a Real (#87, #88), and a string literal of more
---  than one character, which needs somewhere to put the text. Both leave
---  Is_Known False. The real case has to be tested for explicitly: "3.14" would
---  otherwise be fed to String.To_Integer, which reads what it can and returns a
---  quietly wrong answer.
+--  NOT handled, deliberately: a real literal, which needs a place to keep a Real
+--  (#87), and a string literal of more than one character, which needs somewhere
+--  to put the text. Both leave Is_Known False. The real case has to be tested
+--  for explicitly: "3.14" would otherwise be fed to String.To_Integer, which
+--  reads what it can and returns a quietly wrong answer.
+--
+--  Ty is the constant's type (issue #88), and is known in cases where the VALUE
+--  is not: a real constant types as real even though nothing here can hold its
+--  value yet.
 --
 --  The production is read from Concatenated_Image rather than through child
 --  visitors, because its alternatives are token classes and a rule that is just
@@ -35,6 +38,8 @@ feature
 
    Is_Known : Boolean
 
+   Ty : Integer
+
    After_Node
       local
          Image      : String
@@ -42,6 +47,7 @@ feature
          Negative   : Boolean
          First      : Character
          Referenced : detachable Pascal.Checks.Binding
+         T          : Pascal.Checks.Types
       do
          Image := Concatenated_Image
          if Image.Length > 0 then
@@ -56,12 +62,13 @@ feature
             end
 
             if Rest.Length > 0 then
-               if Is_Digit (Rest.Element (1)) then
-                  if not Looks_Real (Rest) then
+               Ty := T.Literal_Type (Rest)
+               if T.Is_Digit (Rest.Element (1)) then
+                  if not T.Looks_Real (Rest) then
                      Value := Rest.To_Integer
                      Is_Known := True
                   end
-               elsif Is_Quote (Rest.Element (1)) then
+               elsif T.Is_Quote (Rest.Element (1)) then
                   Read_Character_Literal (Rest)
                else
                   --  A constant defined in terms of an earlier one, which the
@@ -70,6 +77,7 @@ feature
                   if attached Referenced as B then
                      if B.Is_Constant then
                         Value := B.Value
+                        Ty := B.Ty
                         Is_Known := True
                      end
                   end
@@ -86,42 +94,6 @@ feature
 
 feature { None }
 
-   Is_Digit (Ch : Character) : Boolean
-      --  Character has no Is_Digit, so compare code points: '0' is 48, '9' is 57
-      local
-         Code : Integer
-      do
-         Code.Convert_From (Ch.UTF_32_Code)
-         Result := Code >= 48 and then Code <= 57
-      end
-
-   Looks_Real (Text : String) : Boolean
-      --  A decimal point or an exponent makes it a real literal
-      local
-         Index : Integer
-         Ch    : Character
-      do
-         from
-            Index := 1
-         until
-            Index > Text.Length or else Result
-         loop
-            Ch := Text.Element (Index)
-            if Ch = '.' or else Ch = 'e' or else Ch = 'E' then
-               Result := True
-            end
-            Index := Index + 1
-         end
-      end
-
-   Is_Quote (Ch : Character) : Boolean
-      --  The apostrophe is written ''' -- character_constant is !\'[.]\'!, so
-      --  the middle character may itself be a quote. The double quote is
-      --  accepted too, because this Pascal lexer takes either around a string.
-      do
-         Result := Ch = ''' or else Ch = '"'
-      end
-
    Read_Character_Literal (Text : String)
       --  A single-character literal is its code point. Pascal doubles the quote
       --  to include one, so four quotes denote the quote character itself.
@@ -129,6 +101,7 @@ feature { None }
       local
          Inner : String
          Code  : Integer
+         T     : Pascal.Checks.Types
       do
          if Text.Length >= 2 then
             Inner := Text.Slice (2, Text.Length - 1)
@@ -140,8 +113,8 @@ feature { None }
                Value := Code
                Is_Known := True
             elsif Inner.Length = 2 then
-               if Is_Quote (Inner.Element (1))
-                 and then Is_Quote (Inner.Element (2))
+               if T.Is_Quote (Inner.Element (1))
+                 and then T.Is_Quote (Inner.Element (2))
                then
                   Code.Convert_From (Inner.Element (1).UTF_32_Code)
                   Value := Code

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
@@ -28,6 +28,7 @@ feature
       do
          Value := Child.Value
          Have_Value := Child.Is_Known
+         Ty := Child.Ty
       end
 
    After_Node
@@ -39,7 +40,7 @@ feature
                Error ("duplicate declaration: " & N)
             else
                if Have_Value then
-                  Current_Frame_Scope.Declare_Constant (N, Value)
+                  Current_Frame_Scope.Declare_Constant (N, Value, Ty)
                end
                Decl := Record_Declaration (Current, N, "constant")
                Current_Frame_Scope.Add_Declaration (Decl)
@@ -52,5 +53,6 @@ feature { None }
    Nm         : detachable String
    Value      : Integer
    Have_Value : Boolean
+   Ty         : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-control_variable.aqua
@@ -8,6 +8,10 @@ inherit
 --  its binding and exposes the offset plus whether it is an argument rather than
 --  a local (issue #82); the code stage reads them via type-injection (#66).
 --  Undeclared name is a semantic error.
+--
+--  ISO Pascal requires the control variable to be of an ordinal type, which of
+--  the four modelled types rules out real (issue #88): the loop counts by
+--  successor, and a real has no successor.
 
 feature
 
@@ -18,9 +22,13 @@ feature
    By_Reference : Boolean
 
    After_Node
+      --  The type is a local, not a published attribute: nothing outside reads
+      --  it, and an attribute more on a visitor is not free (issues #107, #120).
       local
-         N : String
-         B : detachable Pascal.Checks.Binding
+         N  : String
+         B  : detachable Pascal.Checks.Binding
+         T  : Pascal.Checks.Types
+         Ty : Integer
       do
          N := Concatenated_Image
          B := Current_Frame_Scope.Lookup (N)
@@ -28,9 +36,14 @@ feature
             Offset := Bound.Offset
             Is_Argument := Bound.Is_Argument
             By_Reference := Bound.By_Reference
+            Ty := Bound.Ty
             if Bound.Is_Constant then
                --  The loop assigns to its control variable
                Error ("cannot use a constant as a loop variable: " & N)
+            end
+            if not T.Is_Quiet (Ty) and then not T.Is_Ordinal (Ty) then
+               Error ("a loop variable must be ordinal, but " & N & " is "
+                      & T.Name (Ty))
             end
             --  The for-loop control variable is written by the loop.
             Refer (Current, "write", Current_Frame_Scope.Lookup_Declaration (N))

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-expression.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-expression.aqua
@@ -8,23 +8,39 @@ inherit
 --  that carries "this expression is a bare variable" up to actual_parameter
 --  (issue #105). A comparison is not a variable, so more than one
 --  simple_expression settles it.
+--
+--  Also the top of the type chain (issue #88): a comparison yields boolean from
+--  two operands that must be compatible, which is where mixing a number with a
+--  boolean or a char is caught.
+--
+--  Every relational operator types the same way, so this rung does not need to
+--  know which one was written -- which is as well, since a visitor bound to the
+--  relational_operator rule crashes the plugin VM (issue #117). 'in' is the one
+--  token that differs, and its right operand is a set_constructor, which is
+--  never typed, so the fold stays quiet about it rather than wrong.
 
 feature
 
    Is_Variable : Boolean
 
+   Ty : Integer
+
    After_Simple_Expression (Child : Pascal.Checks.Simple_Expression)
+      local
+         T : Pascal.Checks.Types
       do
          if Parts = 0 then
             Is_Variable := Child.Is_Variable
+            Ty := Child.Ty
          else
             Is_Variable := False
+            Ty := Combine_Types (T.Compare_Op, Ty, Child.Ty)
          end
          Parts := Parts + 1
       end
 
 feature { None }
 
-   Parts : Integer
+   Parts   : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-factor.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-factor.aqua
@@ -16,9 +16,35 @@ inherit
 --  which is why the code stage has the same chain -- but each rung is a copy.
 --  A parenthesised expression counts: (x) is still the variable x.
 
+--  The leaves of the type chain hang here (issue #88): a variable access, a
+--  literal, a parenthesised expression, and 'not'. A set_constructor has no hook
+--  at all, so it stays No_Type and every operator above it keeps quiet, which is
+--  what an unmodelled construct deserves until sets exist.
+
 feature
 
    Is_Variable : Boolean
+
+   Ty : Integer
+
+   After_Unsigned_Constant (Child : Pascal.Checks.Unsigned_Constant)
+      do
+         Ty := Child.Ty
+      end
+
+   After_Factor (Child : Pascal.Checks.Factor)
+      --  factor as a child of factor is the 'not' alternative, the only one
+      local
+         T : Pascal.Checks.Types
+      do
+         Ty := T.Boolean_Type
+         if not T.Is_Quiet (Child.Ty)
+           and then not (Child.Ty = T.Boolean_Type)
+         then
+            Error ("'not' needs a boolean operand, found " & T.Name (Child.Ty))
+            Ty := T.Error_Type
+         end
+      end
 
    After_Variable_Access (Child : Pascal.Checks.Variable_Access)
       do
@@ -28,11 +54,13 @@ feature
          --  (prgm[i] passed to a var parameter). That the code stage cannot yet
          --  take that address is issue #104, and it says so there.
          Is_Variable := not Child.Is_Call
+         Ty := Child.Ty
       end
 
    After_Expression (Child : Pascal.Checks.Expression)
       do
          Is_Variable := Child.Is_Variable
+         Ty := Child.Ty
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-function_designator.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-function_designator.aqua
@@ -14,18 +14,27 @@ inherit
 --  reference to another plugin object (issue #107) and Integer has no bit
 --  operations (issue #109). Node.Mask_Holds reads it back.
 
+--  Type_Mask carries the type of each argument the same way, three bits apiece
+--  (issue #88). See Pascal.Checks.Actual_Parameter_List for why it is a mask
+--  and not the list it should be.
+
 feature
 
    Count : Integer
 
    Variable_Mask : Integer
 
+   Type_Mask : Integer
+
    After_Actual_Parameter (Child : Pascal.Checks.Actual_Parameter)
+      local
+         T : Pascal.Checks.Types
       do
          Count := Count + 1
          if Child.Is_Variable then
             Variable_Mask := Variable_Mask + Argument_Weight (Count)
          end
+         Type_Mask := Type_Mask + Child.Ty * T.Type_Weight (Count)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-function_heading.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-function_heading.aqua
@@ -14,6 +14,10 @@ inherit
 --  As for a procedure, the name is bound as a routine in the enclosing scope
 --  with a signature the parameters fill in (issue #105); this one returns a
 --  value, so a call to it is legal in an expression.
+--
+--  The result type goes on that signature too (issue #88), which is what gives
+--  a call its type. It arrives last, after the parameters, and lands on the
+--  signature of the scope the heading has already opened.
 
 feature
 
@@ -28,6 +32,13 @@ feature
          create Func_Scope.Make
          Enter_Scope (Func_Scope)
          Current_Frame_Scope.Set_Routine (Sig)
+      end
+
+   After_Result_Type (Child : Pascal.Checks.Result_Type)
+      do
+         if attached Current_Frame_Scope.Routine as Sig then
+            Sig.Set_Result_Type (Child.Ty)
+         end
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-multiplying_operator.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-multiplying_operator.aqua
@@ -1,0 +1,43 @@
+class
+   Pascal.Checks.Multiplying_Operator
+
+inherit
+   Pascal.Checks.Node
+
+--  multiplying_operator ::= '*' | '/' | 'div' | 'mod' | 'and'
+--
+--  Classifies the token into the typing rule its enclosing term must apply
+--  (issue #88). The three operator levels share five rules, described on
+--  Pascal.Checks.Types, and fold through Node.Combine_Types.
+--
+--  This is where Pascal's two divisions separate: '/' yields a real however
+--  integral its operands are, while 'div' and 'mod' take integers only. The
+--  code stage still maps both to one Divide (issue #87).
+
+feature
+
+   Kind : Integer
+
+   After_Node
+      local
+         T : Pascal.Checks.Types
+         S : String
+      do
+         --  Concatenated_Image, not Standard_Text: see the note in
+         --  Pascal.Checks.Adding_Operator.
+         S := Concatenated_Image
+         S := S.To_Lower
+         if S.Equal ("*") then
+            Kind := T.Arithmetic_Op
+         elsif S.Equal ("/") then
+            Kind := T.Real_Divide_Op
+         elsif S.Equal ("div") or else S.Equal ("mod") then
+            Kind := T.Integer_Op
+         elsif S.Equal ("and") then
+            Kind := T.Boolean_Op
+         else
+            Kind := T.No_Op
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -16,6 +16,15 @@ inherit
 --  sees the same instance. It owns the slot counter for the whole program;
 --  Current_Frame_Scope is the scope declarations and accesses actually use
 --  (issue #81).
+--
+--  KEEP THIS CLASS SMALL. Every checks visitor inherits it, and it does not
+--  take growth well: adding an attribute here corrupted generated code once
+--  already (issue #107), and adding a handful of FEATURES here made a visitor
+--  bound to adding_operator fault the VM while resolving an unrelated node
+--  (issue #117 -- reproduced, bisected, and fixed by moving five of them off).
+--  Anything that does not need the tree -- no Error, no Current, no scope --
+--  belongs on Pascal.Checks.Types, which nothing inherits. What is left here is
+--  the code that must report through Error or reach the current scope.
 
 feature
 
@@ -120,12 +129,17 @@ feature
          Result := Current_Frame_Scope.Declare_Routine (Name, Sig)
       end
 
-   Declare_Parameters (List         : Pascal.Checks.Identifier_List
+   Declare_Parameters (Names        : Aqua.Containers.Linked_List [String]
                        By_Reference : Boolean
-                       Category     : String)
-      --  Bind each name in List as an argument of the routine whose scope is
-      --  current (issue #82). Shared by the value and var parameter
-      --  specifications, which differ only in By_Reference and Category.
+                       Category     : String
+                       Type_Code    : Integer)
+      --  Bind each name as an argument of the routine whose scope is current
+      --  (issue #82). Shared by the value and var parameter specifications,
+      --  which differ only in By_Reference and Category.
+      --
+      --  Takes the name list rather than the identifier_list visitor that owns
+      --  it: the caller has to hold it until its type has been seen, and a list
+      --  of strings is a library object rather than another plugin visitor.
       --
       --  The redeclaration check is Is_Declared_Here, so repeating a name within
       --  one parameter list, or between the parameters and the body's locals, is
@@ -138,7 +152,7 @@ feature
          Decl   : Aquarius.Entities.Declaration
       do
          from
-            It := List.Names.New_Cursor
+            It := Names.New_Cursor
          until
             It.After
          loop
@@ -147,11 +161,15 @@ feature
                Error ("duplicate declaration: " & Name)
             else
                Ignore :=
-                  Current_Frame_Scope.Declare_Argument (Name, By_Reference)
+                  Current_Frame_Scope.Declare_Argument
+                     (Name, By_Reference, Type_Code)
                --  Record it in the routine's signature too, so a call can be
-               --  checked against it (issue #105)
+               --  checked against it (issue #105), including its type (#88):
+               --  a parameter slot's content has to be declared for the caller
+               --  and the callee to agree on the frame, which is the one place
+               --  a type is not inferable from the accesses alone.
                if attached Current_Frame_Scope.Routine as Sig then
-                  Sig.Add_Parameter (By_Reference)
+                  Sig.Add_Parameter (By_Reference, Type_Code)
                end
                Decl := Record_Declaration (Current, Name, Category)
                Current_Frame_Scope.Add_Declaration (Decl)
@@ -247,6 +265,121 @@ feature
          Decl.Set_Top_Level
          Environment.Add_Declaration (Decl)
          Global_Scope.Add_Declaration (Decl)
+      end
+
+   Declare_Builtin_Types
+      --  Bind the four modelled type names in the ROOT frame scope (issue #88),
+      --  so that resolving a type_denoter is the same lookup as resolving a
+      --  variable. Like Declare_Builtin_Routines, and for the same reason, this
+      --  runs for each program rather than once: Program.Before_Node resets the
+      --  root scope, and Ensure_Builtins handles the entity-model side.
+      --
+      --  'text' is deliberately absent. It is a file type, which this system
+      --  does not model, and leaving it unbound makes a variable declared with
+      --  it resolve to Unknown, which is what it is.
+      local
+         T : Pascal.Checks.Types
+      do
+         Scope.Declare_Type ("integer", T.Integer_Type)
+         Scope.Declare_Type ("real",    T.Real_Type)
+         Scope.Declare_Type ("boolean", T.Boolean_Type)
+         Scope.Declare_Type ("char",    T.Char_Type)
+      end
+
+   Resolve_Type_Name (Text : String) : Integer
+      --  The type a type_denoter or type_identifier stands for. Anything that
+      --  is not one of the four modelled names -- a record, an array, a pointer,
+      --  a subrange, a user type that is not an alias of a built-in -- comes
+      --  back as Unknown, which is reported where it is used rather than here.
+      local
+         T : Pascal.Checks.Types
+      do
+         Result := Current_Frame_Scope.Lookup_Type (Text)
+         if Result = T.No_Type then
+            Result := T.Unknown_Type
+         end
+      end
+
+   Combine_Types (Op : Integer; Left : Integer; Right : Integer) : Integer
+      --  The type of "Left op Right", reporting the operand types if the
+      --  operator cannot take them (issue #88). Shared by all three operator
+      --  levels, which differ only in which tokens map to which rule.
+      --
+      --  The rules themselves are on Pascal.Checks.Types; all that is here is
+      --  the reporting, which needs the tree. See the note on this class about
+      --  keeping it small.
+      local
+         T   : Pascal.Checks.Types
+         Msg : String
+      do
+         Msg := T.Combine_Message (Op, Left, Right)
+         if Msg.Length > 0 then
+            Error (Msg)
+         end
+         Result := T.Combine (Op, Left, Right)
+      end
+
+   Check_Argument_Types (Name        : String
+                         Sig         : Pascal.Checks.Signature
+                         Given       : Integer
+                         Actual_Mask : Integer)
+      --  Check each actual against the parameter it is passed to (issue #88),
+      --  extending the arity and var-parameter checks of issue #105. Shared by
+      --  a call in an expression and a procedure statement.
+      --
+      --  A variadic routine is skipped whole: write and writeln take anything,
+      --  in any number, and have no parameter list to check against.
+      --
+      --  A var parameter takes its actual by address, so it wants that exact
+      --  type -- there is nowhere to put the promoted copy that a value
+      --  parameter would receive.
+      local
+         Index  : Integer
+         Formal : Integer
+         Actual : Integer
+         T      : Pascal.Checks.Types
+      do
+         if not Sig.Is_Variadic then
+            from
+               Index := 0
+            until
+               Index >= Given
+            loop
+               Index := Index + 1
+               Actual := T.Packed_Type (Actual_Mask, Index)
+               Formal := Sig.Parameter_Type (Index)
+               if T.Is_Known (Formal) and then not T.Is_Quiet (Actual) then
+                  if Sig.Parameter_By_Reference (Index) then
+                     if not (Formal = Actual) then
+                        Error ("argument " & Index.To_String & " of " & Name
+                               & " is a var " & T.Name (Formal)
+                               & ", so a " & T.Name (Actual)
+                               & " cannot be passed to it")
+                     end
+                  elsif not T.Assignable (Formal, Actual) then
+                     Error ("argument " & Index.To_String & " of " & Name
+                            & " is " & T.Name (Formal) & ", but a "
+                            & T.Name (Actual) & " was given")
+                  end
+               end
+            end
+         end
+      end
+
+   Check_Known (Code : Integer; Role : String) : Integer
+      --  Report an operand whose type is outside the model, in a position that
+      --  is not an operator -- an assignment side, a for-loop bound, a call
+      --  argument. Returns the code to carry on with, poisoned if reported.
+      local
+         T : Pascal.Checks.Types
+      do
+         if T.Is_Quiet (Code) or else T.Is_Known (Code) then
+            Result := Code
+         else
+            Error ("unsupported type for " & Role & ": only integer, real,"
+                   & " boolean and char are modelled")
+            Result := T.Error_Type
+         end
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_statement.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_statement.aqua
@@ -24,6 +24,7 @@ feature
       do
          Given_Arguments := Child.Count
          Argument_Variables := Child.Variable_Mask
+         Argument_Types := Child.Type_Mask
       end
 
    After_Node
@@ -43,6 +44,8 @@ feature
                                & ", found " & Given_Arguments.To_String)
                      else
                         Check_Var_Arguments (N, Sig)
+                        Check_Argument_Types (N, Sig, Given_Arguments,
+                                              Argument_Types)
                      end
                   end
                   Refer (Current, "call",
@@ -62,6 +65,9 @@ feature { None }
    Given_Arguments    : Integer
    Argument_Variables : Integer
       --  One bit per argument, set when it is a bare variable (issue #107)
+
+   Argument_Types : Integer
+      --  One type code per argument, three bits apiece (issue #88)
 
    Check_Var_Arguments (Name : String; Sig : Pascal.Checks.Signature)
       --  A var parameter is passed by address, so its actual has to be something

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
@@ -25,6 +25,7 @@ feature
          --  last program compiled in this session.
          Scope.Reset
          Context.Set_Current_Frame_Scope (Scope)
+         Declare_Builtin_Types
          Declare_Builtin_Routines
          create Program_Scope.Make
          Enter_Scope (Program_Scope)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-result_type.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-result_type.aqua
@@ -1,0 +1,21 @@
+class
+   Pascal.Checks.Result_Type
+
+inherit
+   Pascal.Checks.Node
+
+--  result_type ::= type_identifier
+--
+--  A rung of its own because a function_heading sees its direct children only,
+--  and the type_identifier is nested inside this rule (issue #88).
+
+feature
+
+   Ty : Integer
+
+   After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
+      do
+         Ty := Child.Ty
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -73,20 +73,28 @@ feature
 
 feature  --  declaring
 
-   Declare_Local (Name : String) : Integer
+   Declare_Local (Name : String; Type_Code : Integer) : Integer
       --  Bind Name in THIS scope to a freshly allocated frame slot, and return
       --  the slot. The caller is expected to have checked Find first: declaring
       --  the same name twice in one scope leaves both bindings, and Find will
       --  answer with the first.
+      --
+      --  One slot per name whatever the type, including a real (issue #88).
+      --  A slot index is not a word offset: Tagatha's Aqua backend maps slot to
+      --  register with its own prefix sum over Slot_Width, widening a slot that
+      --  is pushed or popped as floating point to the pair it needs. A second
+      --  prefix sum here would compose wrongly with that one.
       local
          B : Pascal.Checks.Binding
       do
          Result := Allocate
-         create B.Make_Local (Name, Result)
+         create B.Make_Local (Name, Result, Type_Code)
          Bindings.Append (B)
       end
 
-   Declare_Argument (Name : String; By_Reference : Boolean) : Integer
+   Declare_Argument (Name : String
+                     By_Reference : Boolean
+                     Type_Code : Integer) : Integer
       --  Bind Name in THIS scope to the next argument index of the routine this
       --  scope belongs to, and return the index. Same caller contract as
       --  Declare_Local: check Find first.
@@ -95,7 +103,7 @@ feature  --  declaring
       do
          Allocated_Arguments := Allocated_Arguments + 1
          Result := Allocated_Arguments
-         create B.Make_Argument (Name, Result, By_Reference)
+         create B.Make_Argument (Name, Result, By_Reference, Type_Code)
          Bindings.Append (B)
       end
 
@@ -126,13 +134,24 @@ feature  --  declaring
          end
       end
 
-   Declare_Constant (Name : String; Value : Integer)
+   Declare_Constant (Name : String; Value : Integer; Type_Code : Integer)
       --  Bind Name in THIS scope to a value (issue #103). Nothing is allocated:
       --  a constant is not storage, so it takes no slot in either index space.
       local
          B : Pascal.Checks.Binding
       do
-         create B.Make_Constant (Name, Value)
+         create B.Make_Constant (Name, Value, Type_Code)
+         Bindings.Append (B)
+      end
+
+   Declare_Type (Name : String; Type_Code : Integer)
+      --  Bind Name in THIS scope as the name of a type (issue #88). Used for
+      --  the four built-ins, declared into the root scope for each program, and
+      --  for a user alias of one of them.
+      local
+         B : Pascal.Checks.Binding
+      do
+         create B.Make_Type (Name, Type_Code)
          Bindings.Append (B)
       end
 
@@ -246,6 +265,22 @@ feature  --  resolving
          B := Lookup (Name)
          if attached B as Found then
             Result := Found.Offset
+         end
+      end
+
+   Lookup_Type (Name : String) : Integer
+      --  The type the innermost Name stands for, or 0 -- Types.No_Type -- if
+      --  the name is not bound, or is bound to something that is not a type.
+      --  Left as the default rather than naming the constant, so that the
+      --  symbol table stays independent of the type codes, as Offset is.
+      local
+         B : detachable Pascal.Checks.Binding
+      do
+         B := Lookup (Name)
+         if attached B as Found then
+            if Found.Is_Type then
+               Result := Found.Ty
+            end
          end
       end
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-signature.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-signature.aqua
@@ -5,7 +5,8 @@ create
    Make
 
 --  What a call has to agree with: how many parameters a routine takes, which of
---  them are passed by reference, and whether it returns a value (issue #105).
+--  them are passed by reference, whether it returns a value (issue #105), and
+--  the type of each parameter and of the result (issue #88).
 --
 --  A signature outlives the scope it describes. A routine's own scope -- which
 --  holds its parameter bindings and knows how many there are -- is popped when
@@ -21,6 +22,7 @@ feature
    Make (Returns_A_Value : Boolean; Any_Argument_Count : Boolean)
       do
          create By_Reference_Flags
+         create Parameter_Types
          Argument_Count := 0
          Is_Function := Returns_A_Value
          Is_Variadic := Any_Argument_Count
@@ -32,13 +34,24 @@ feature
 
    Is_Variadic : Boolean
 
-   Add_Parameter (By_Reference : Boolean)
+   Result_Type : Integer
+      --  The Pascal.Checks.Types code a call to this routine yields, from the
+      --  result_type on a function heading (issue #88). Zero -- No_Type -- for
+      --  a procedure, and for a function whose result type is not modelled.
+
+   Set_Result_Type (Type_Code : Integer)
+      do
+         Result_Type := Type_Code
+      end
+
+   Add_Parameter (By_Reference : Boolean; Type_Code : Integer)
       do
          if By_Reference then
             By_Reference_Flags.Append (1)
          else
             By_Reference_Flags.Append (0)
          end
+         Parameter_Types.Append (Type_Code)
          Argument_Count := Argument_Count + 1
       end
 
@@ -66,8 +79,34 @@ feature
          end
       end
 
+   Parameter_Type (Index : Integer) : Integer
+      --  The declared type of parameter Index (1-based), or 0 -- No_Type -- for
+      --  an index out of range, which the arity check reports separately and
+      --  which the type check then stays quiet about.
+      local
+         It : Aqua.Containers.Linked_List_Iterator [Integer]
+         At : Integer
+      do
+         from
+            It := Parameter_Types.New_Cursor
+            At := 0
+         until
+            It.After
+         loop
+            At := At + 1
+            if At = Index then
+               Result := It.Element
+            end
+            It.Next
+         end
+      end
+
 feature { None }
 
    By_Reference_Flags : Aqua.Containers.Linked_List [Integer]
+
+   Parameter_Types : Aqua.Containers.Linked_List [Integer]
+      --  Type codes, in declaration order. A list of Integer for the same
+      --  reason as By_Reference_Flags above.
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-simple_expression.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-simple_expression.aqua
@@ -7,29 +7,55 @@ inherit
 --  simple_expression ::= [ sign ] < term / adding_operator >. A bare variable
 --  only if it is one term with no sign and no operator: -x and x + 1 are not
 --  variables (issue #105).
+--
+--  Types '+', '-' and 'or' the way term types its own operators (issue #88). A
+--  leading sign is the one unary case here: it needs a numeric term, and leaves
+--  the type alone.
 
 feature
 
    Is_Variable : Boolean
+
+   Ty : Integer
 
    After_Sign (Child : Pascal.Checks.Sign)
       do
          Signed := True
       end
 
+   After_Adding_Operator (Child : Pascal.Checks.Adding_Operator)
+      do
+         Pending := Child.Kind
+      end
+
    After_Term (Child : Pascal.Checks.Term)
+      local
+         T : Pascal.Checks.Types
       do
          if Terms = 0 and then not Signed then
             Is_Variable := Child.Is_Variable
+            Ty := Child.Ty
          else
             Is_Variable := False
+            if Terms = 0 then
+               --  Signed: '-' and '+' on their own take a number
+               Ty := Child.Ty
+               if not T.Is_Quiet (Ty) and then not T.Is_Numeric (Ty) then
+                  Error ("a sign needs a numeric operand, found "
+                         & T.Name (Ty))
+                  Ty := T.Error_Type
+               end
+            else
+               Ty := Combine_Types (Pending, Ty, Child.Ty)
+            end
          end
          Terms := Terms + 1
       end
 
 feature { None }
 
-   Terms  : Integer
-   Signed : Boolean
+   Terms   : Integer
+   Signed  : Boolean
+   Pending : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-term.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-term.aqua
@@ -6,17 +6,31 @@ inherit
 
 --  term ::= < factor / multiplying_operator >. A bare variable only if it is one
 --  factor and no operator: x is a variable, x * 2 is not (issue #105).
+--
+--  Also the rung where '*', '/', 'div', 'mod' and 'and' type their operands
+--  (issue #88). The operator reduces between its two factors, so Pending holds
+--  the rule to apply until the right-hand factor arrives -- the same shape the
+--  code stage uses to hold its Ast operator.
 
 feature
 
    Is_Variable : Boolean
 
+   Ty : Integer
+
+   After_Multiplying_Operator (Child : Pascal.Checks.Multiplying_Operator)
+      do
+         Pending := Child.Kind
+      end
+
    After_Factor (Child : Pascal.Checks.Factor)
       do
          if Factors = 0 then
             Is_Variable := Child.Is_Variable
+            Ty := Child.Ty
          else
             Is_Variable := False
+            Ty := Combine_Types (Pending, Ty, Child.Ty)
          end
          Factors := Factors + 1
       end
@@ -24,5 +38,6 @@ feature
 feature { None }
 
    Factors : Integer
+   Pending : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-type_definition.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-type_definition.aqua
@@ -5,8 +5,15 @@ inherit
    Pascal.Checks.Node
 
 --  type_definition ::= identifier '=' type_denoter. Records the type's name in
---  the current entity scope (issue #74). The denoted type is not resolved and
---  no structural type model is built (minimal semantic pass).
+--  the current entity scope (issue #74). No structural type model is built
+--  (minimal semantic pass).
+--
+--  An alias of a built-in -- Counter = integer -- is bound as a type name in the
+--  frame scope, so that a variable declared with it is typed as what it aliases
+--  (issue #88). Anything else denotes a type outside the model and is bound as
+--  Unknown, which is honest: a use of it is then reported rather than guessed at.
+--  Binding it either way matters, because an unbound name would resolve to
+--  whatever a variable of the same name happened to be.
 
 feature
 
@@ -14,7 +21,26 @@ feature
       local
          Ignore : Aquarius.Entities.Declaration
       do
+         Nm := Name
          Ignore := Record_Declaration (Current, Name, "type")
       end
+
+   After_Type_Denoter (Child : Pascal.Checks.Type_Denoter)
+      do
+         Ty := Child.Ty
+      end
+
+   After_Node
+      do
+         if attached Nm as Defined then
+            Current_Frame_Scope.Declare_Type (Defined, Ty)
+         end
+      end
+
+feature { None }
+
+   Nm : detachable String
+
+   Ty : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-type_denoter.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-type_denoter.aqua
@@ -1,0 +1,42 @@
+class
+   Pascal.Checks.Type_Denoter
+
+inherit
+   Pascal.Checks.Node
+
+--  type_denoter ::= type_identifier | new_type
+--
+--  Publishes the type its enclosing variable_declaration or type_definition is
+--  declaring (issue #88).
+--
+--  Only the type_identifier alternative is resolved, and through the child
+--  rather than through this node's own text. A new_type -- a record, an array, a
+--  set, a subrange, a pointer -- fires no hook and stays Unknown, which is what
+--  it is to a system that models four scalar types; structured types are issue
+--  #104.
+--
+--  Reading Concatenated_Image here would answer both alternatives at once, and
+--  is how this was first written, but the image of a whole record denotation is
+--  far longer than the 252 characters the tree device can pass back to the
+--  plugin, and overflowing that window kills the run with a range check
+--  (issue #118). The child's image is a single identifier.
+
+feature
+
+   Ty : Integer
+
+   After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
+      do
+         Ty := Child.Ty
+      end
+
+   After_Node
+      local
+         T : Pascal.Checks.Types
+      do
+         if Ty = T.No_Type then
+            Ty := T.Unknown_Type
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-type_identifier.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-type_identifier.aqua
@@ -1,0 +1,21 @@
+class
+   Pascal.Checks.Type_Identifier
+
+inherit
+   Pascal.Checks.Node
+
+--  type_identifier ::= identifier
+--
+--  The type named by a parameter specification or a function's result_type,
+--  neither of which goes through type_denoter (issue #88).
+
+feature
+
+   Ty : Integer
+
+   After_Node
+      do
+         Ty := Resolve_Type_Name (Concatenated_Image)
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-types.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-types.aqua
@@ -1,0 +1,348 @@
+expanded class
+   Pascal.Checks.Types
+
+--  The type codes of the minimal Pascal type system (issue #88): integer, real,
+--  boolean and char, and nothing else. Codes rather than objects, following
+--  Ast.Operator, because a visitor publishes its type as a plain Integer for the
+--  code stage to read, and because Integer has neither bit operations (issue
+--  #109) nor a safe generic '=' (issue #60) to build anything richer with.
+--
+--  Two codes stand outside the model and are the reason a check can be made
+--  without drowning a program in messages:
+--
+--    Unknown is a type the system does not model -- a record, an array, a
+--    pointer, a set, a string literal, nil. It is reported when it is USED,
+--    which is what makes the check honest rather than silently permissive.
+--
+--    Error is poison. It is what an operand becomes once its problem has been
+--    reported, and it is compatible with everything, so one mistyped subterm
+--    yields one message rather than one per enclosing operator.
+--
+--  No_Type is the initial value of an untyped node, and is treated like Error:
+--  nothing is known, so nothing is claimed.
+
+feature
+
+   No_Type      : Integer do Result := 0 end
+   Integer_Type : Integer do Result := 1 end
+   Real_Type    : Integer do Result := 2 end
+   Boolean_Type : Integer do Result := 3 end
+   Char_Type    : Integer do Result := 4 end
+   Unknown_Type : Integer do Result := 5 end
+   Error_Type   : Integer do Result := 6 end
+
+   Name (Code : Integer) : String
+      --  For error messages
+      do
+         if Code = Integer_Type then
+            Result := "integer"
+         elsif Code = Real_Type then
+            Result := "real"
+         elsif Code = Boolean_Type then
+            Result := "boolean"
+         elsif Code = Char_Type then
+            Result := "char"
+         else
+            Result := "unknown type"
+         end
+      end
+
+   Is_Known (Code : Integer) : Boolean
+      --  One of the four modelled types: worth checking, and worth reporting
+      --  about. Anything else has either not been typed or has been reported.
+      do
+         Result := Code >= Integer_Type and then Code <= Char_Type
+      end
+
+   Is_Quiet (Code : Integer) : Boolean
+      --  Say nothing about this operand: it is poison from an error already
+      --  reported, or a node the pass never typed.
+      do
+         Result := Code = Error_Type or else Code = No_Type
+      end
+
+   Is_Numeric (Code : Integer) : Boolean
+      do
+         Result := Code = Integer_Type or else Code = Real_Type
+      end
+
+   Is_Ordinal (Code : Integer) : Boolean
+      --  What a for-loop control variable and a case selector must be. Real is
+      --  the one modelled type that is not ordinal.
+      do
+         Result := Code = Integer_Type or else Code = Boolean_Type
+            or else Code = Char_Type
+      end
+
+   Assignable (Target : Integer; Source : Integer) : Boolean
+      --  Pascal assignment compatibility for the modelled types: identical, or
+      --  the one widening the language performs for you, integer to real. The
+      --  reverse needs an explicit round or trunc.
+      do
+         if Is_Quiet (Target) or else Is_Quiet (Source) then
+            Result := True
+         elsif Target = Source then
+            Result := True
+         else
+            Result := Target = Real_Type and then Source = Integer_Type
+         end
+      end
+
+   Both_Numeric (Left : Integer; Right : Integer) : Boolean
+      do
+         Result := Is_Numeric (Left) and then Is_Numeric (Right)
+      end
+
+   --  How an operator constrains its operands. The three operator rungs --
+   --  multiplying, adding and relational -- have five typing rules between
+   --  them, not fifteen, so each classifies its token into one of these and
+   --  they share one fold.
+   --
+   --  The relational rung does not classify at all: every relational operator
+   --  yields a boolean from two compatible operands, so it passes Compare_Op
+   --  and needs no visitor of its own. 'in' is the exception, and its right
+   --  operand is a set_constructor, which is never typed, so the fold stays
+   --  quiet about it rather than wrong.
+
+   No_Op          : Integer do Result := 0 end
+   Arithmetic_Op  : Integer do Result := 1 end
+   Real_Divide_Op : Integer do Result := 2 end
+   Integer_Op     : Integer do Result := 3 end
+   Boolean_Op     : Integer do Result := 4 end
+   Compare_Op     : Integer do Result := 5 end
+
+   Operand_Requirement (Op : Integer) : String
+      --  What the operator wanted, for the error message
+      do
+         if Op = Boolean_Op then
+            Result := "boolean"
+         elsif Op = Integer_Op then
+            Result := "integer"
+         else
+            Result := "numeric"
+         end
+      end
+
+   --  The fold itself, in two halves: what the combination yields, and what to
+   --  say if it is illegal. Both are pure, and both live here rather than on
+   --  Pascal.Checks.Node, which reports the message. Node is the base of every
+   --  checks visitor, and features accumulated on it break the plugin VM in
+   --  unrelated places (issues #107, #117), so it keeps only the thin wrapper
+   --  that needs Error.
+
+   --  Argument types travel from a call's argument list to the check against
+   --  its signature packed into one Integer, three bits per argument, exactly
+   --  as the var-parameter flags travel as one bit per argument. A list would
+   --  read better, but a Linked_List attribute on THOSE visitors faults the VM
+   --  (issue #120), and Integer has no bit operations (issue #109), so the
+   --  packing is arithmetic: base 8, since the codes run 0 .. 6.
+
+   Type_Slot_Limit : Integer
+      --  Arguments past the tenth are not represented: ten slots of three bits
+      --  is thirty, and an Integer is thirty-two. A call that long simply goes
+      --  unchecked rather than wrong.
+      do
+         Result := 10
+      end
+
+   Type_Weight (Index : Integer) : Integer
+      --  8 ** (Index - 1), the place value of argument Index. Zero beyond the
+      --  limit, which is what stops anything being packed there.
+      local
+         At : Integer
+      do
+         if Index >= 1 and then Index <= Type_Slot_Limit then
+            Result := 1
+            from
+               At := 1
+            until
+               At >= Index
+            loop
+               Result := Result * 8
+               At := At + 1
+            end
+         end
+      end
+
+   Packed_Type (Mask : Integer; Index : Integer) : Integer
+      --  The code packed at Index, or No_Type past the limit
+      local
+         Weight : Integer
+      do
+         Weight := Type_Weight (Index)
+         if Weight > 0 then
+            Result := (Mask / Weight) mod 8
+         end
+      end
+
+   Legal (Op : Integer; Left : Integer; Right : Integer) : Boolean
+      --  Whether the operator accepts these two operand types. Only ever asked
+      --  about two known types: quiet and unknown operands are settled first.
+      do
+         if Op = Boolean_Op then
+            Result := Left = Boolean_Type and then Right = Boolean_Type
+         elsif Op = Integer_Op then
+            Result := Left = Integer_Type and then Right = Integer_Type
+         elsif Op = Compare_Op then
+            --  Comparable if either side would be assignable to the other,
+            --  which admits integer against real and nothing else mixed.
+            Result := Assignable (Left, Right) or else Assignable (Right, Left)
+         else
+            --  Arithmetic and real division both want numbers
+            Result := Both_Numeric (Left, Right)
+         end
+      end
+
+   Yield (Op : Integer; Left : Integer; Right : Integer) : Integer
+      --  What a legal combination produces
+      do
+         if Op = Compare_Op then
+            Result := Boolean_Type
+         elsif Op = Boolean_Op then
+            Result := Boolean_Type
+         elsif Op = Integer_Op then
+            Result := Integer_Type
+         elsif Op = Real_Divide_Op then
+            --  '/' is real division: integral operands and all
+            Result := Real_Type
+         else
+            Result := Arithmetic_Result (Left, Right)
+         end
+      end
+
+   Combine (Op : Integer; Left : Integer; Right : Integer) : Integer
+      --  The type of "Left op Right". Error is poison, and is what an illegal
+      --  or already-reported combination yields, so that one mistyped subterm
+      --  produces one message rather than one per enclosing operator.
+      do
+         if Op = No_Op then
+            Result := No_Type
+         elsif Is_Quiet (Left) or else Is_Quiet (Right) then
+            Result := Error_Type
+         elsif not Is_Known (Left) or else not Is_Known (Right) then
+            Result := Error_Type
+         elsif Legal (Op, Left, Right) then
+            Result := Yield (Op, Left, Right)
+         else
+            Result := Error_Type
+         end
+      end
+
+   Combine_Message (Op : Integer; Left : Integer; Right : Integer) : String
+      --  What to report about "Left op Right", or the empty string if there is
+      --  nothing to say. Kept beside Combine so the two agree about what is
+      --  legal; the caller reports it.
+      do
+         Result := ""
+         if Op = No_Op then
+         elsif Is_Quiet (Left) or else Is_Quiet (Right) then
+         elsif not Is_Known (Left) or else not Is_Known (Right) then
+            Result := "unsupported operand type: only integer, real, boolean"
+               & " and char are modelled"
+         elsif Legal (Op, Left, Right) then
+         elsif Op = Compare_Op then
+            Result := "cannot compare " & Name (Left) & " with " & Name (Right)
+         else
+            Result := "operator requires " & Operand_Requirement (Op)
+               & " operands, found " & Name (Left) & " and " & Name (Right)
+         end
+      end
+
+   Literal_Type (Text : String) : Integer
+      --  The type of a literal, from its text with any sign already peeled off.
+      --  Shared by unsigned_constant in an expression and by constant in a const
+      --  definition. A name is No_Type: the caller resolves it.
+      --
+      --  This and the spelling predicates below live here, on a class nobody
+      --  inherits, rather than on Pascal.Checks.Node. Node is the base of every
+      --  checks visitor, and features added to it break the plugin VM in ways
+      --  that show up in unrelated places (issues #107, #117).
+      do
+         if Text.Length = 0 then
+            Result := No_Type
+         elsif Is_Digit (Text.Element (1)) then
+            if Looks_Real (Text) then
+               Result := Real_Type
+            else
+               Result := Integer_Type
+            end
+         elsif Is_Quote (Text.Element (1)) then
+            if Is_Character_Literal (Text) then
+               Result := Char_Type
+            else
+               --  A string of more than one character: no place to put the
+               --  text, and no string type in the model (issue #88).
+               Result := Unknown_Type
+            end
+         elsif Text.Length = 3 then
+            if Text.To_Lower.Equal ("nil") then
+               Result := Unknown_Type
+            end
+         end
+      end
+
+   Is_Digit (Ch : Character) : Boolean
+      --  Character has no Is_Digit, so compare code points: '0' is 48, '9' is 57
+      local
+         Code : Integer
+      do
+         Code.Convert_From (Ch.UTF_32_Code)
+         Result := Code >= 48 and then Code <= 57
+      end
+
+   Looks_Real (Text : String) : Boolean
+      --  A decimal point or an exponent makes it a real literal
+      local
+         Index : Integer
+         Ch    : Character
+      do
+         from
+            Index := 1
+         until
+            Index > Text.Length or else Result
+         loop
+            Ch := Text.Element (Index)
+            if Ch = '.' or else Ch = 'e' or else Ch = 'E' then
+               Result := True
+            end
+            Index := Index + 1
+         end
+      end
+
+   Is_Quote (Ch : Character) : Boolean
+      --  The apostrophe is written ''' -- character_constant is !\'[.]\'!, so
+      --  the middle character may itself be a quote. The double quote is
+      --  accepted too, because this Pascal lexer takes either around a string.
+      do
+         Result := Ch = ''' or else Ch = '"'
+      end
+
+   Is_Character_Literal (Text : String) : Boolean
+      --  A quoted literal of exactly one character, counting the doubled quote
+      --  that denotes the quote itself.
+      local
+         Inner : String
+      do
+         if Text.Length >= 2 then
+            Inner := Text.Slice (2, Text.Length - 1)
+            if Inner.Length = 1 then
+               Result := True
+            elsif Inner.Length = 2 then
+               Result := Is_Quote (Inner.Element (1))
+                  and then Is_Quote (Inner.Element (2))
+            end
+         end
+      end
+
+   Arithmetic_Result (Left : Integer; Right : Integer) : Integer
+      --  The type of Left op Right for '+', '-' and '*': real if either side
+      --  is, integer otherwise. The promotion is the caller's to generate.
+      do
+         if Left = Real_Type or else Right = Real_Type then
+            Result := Real_Type
+         else
+            Result := Integer_Type
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-unsigned_constant.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-unsigned_constant.aqua
@@ -1,0 +1,54 @@
+class
+   Pascal.Checks.Unsigned_Constant
+
+inherit
+   Pascal.Checks.Node
+
+--  unsigned_constant ::= numeric_literal | string_literal | 'nil'
+--
+--  Types a literal where it appears in an expression (issue #88). The const
+--  section has its own path through Pascal.Checks.Constant, which additionally
+--  evaluates the literal; here only the type is wanted.
+--
+--  numeric_literal is the standard ada_numeric_literal, so a decimal point or an
+--  exponent is what separates 3.14 and 1.0e10 from 42 and 16#FF#. A string
+--  literal of one character is a char; a longer one is not modelled, and neither
+--  is nil, which is a keyword and so fires no hook at all.
+--
+--  Taken from the token hooks rather than from this node's Concatenated_Image so
+--  that the string handed across the tree device is the literal itself and never
+--  more (issue #118).
+
+feature
+
+   Ty : Integer
+
+   After_Numeric_Literal (Value : String)
+      local
+         T : Pascal.Checks.Types
+      do
+         Ty := T.Literal_Type (Value)
+      end
+
+   After_String_Literal (Value : String)
+      local
+         T : Pascal.Checks.Types
+      do
+         if T.Is_Character_Literal (Value) then
+            Ty := T.Char_Type
+         else
+            Ty := T.Unknown_Type
+         end
+      end
+
+   After_Node
+      local
+         T : Pascal.Checks.Types
+      do
+         if Ty = T.No_Type then
+            --  nil
+            Ty := T.Unknown_Type
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
@@ -13,12 +13,35 @@ inherit
 --  Also recorded in the entity model as a "parameter" (issue #74), and in the
 --  frame scope's declarations so a reference to the parameter can resolve to it
 --  and record a cross reference.
+--
+--  The declared type reaches the binding and the routine's signature (issue
+--  #88), which is what lets a call be checked against it. As in a variable
+--  declaration, the names reduce before the type does, so the binding waits for
+--  After_Node.
 
 feature
 
    After_Identifier_List (Child : Pascal.Checks.Identifier_List)
       do
-         Declare_Parameters (Child, False, "parameter")
+         Names := Child.Names
       end
+
+   After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
+      do
+         Ty := Child.Ty
+      end
+
+   After_Node
+      do
+         if attached Names as Declared then
+            Declare_Parameters (Declared, False, "parameter", Ty)
+         end
+      end
+
+feature { None }
+
+   Names : detachable Aqua.Containers.Linked_List [String]
+
+   Ty : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -46,6 +46,13 @@ feature
 
    Is_Target : Boolean
 
+   Ty : Integer
+      --  What this access yields (issue #88): the bound name's type, or the
+      --  result type of the function when it is a call. This is the leaf the
+      --  whole expression chain is typed from, and -- since this object is the
+      --  one the code stage receives by injection -- the type it will read to
+      --  choose a float operator (issue #87).
+
    Set_Target
       do
          Is_Target := True
@@ -62,6 +69,7 @@ feature
             Has_Argument_List := True
             Given_Arguments := Child.Argument_Count
             Argument_Variables := Child.Variable_Mask
+            Argument_Types := Child.Type_Mask
          else
             Is_Component := True
          end
@@ -70,6 +78,7 @@ feature
    After_Node
       local
          B : detachable Pascal.Checks.Binding
+         T : Pascal.Checks.Types
       do
          if attached Nm as N then
             B := Current_Frame_Scope.Lookup (N)
@@ -82,6 +91,7 @@ feature
                   By_Reference := Bound.By_Reference
                   Is_Constant := Bound.Is_Constant
                   Value := Bound.Value
+                  Ty := Bound.Ty
                   if Is_Constant and then Is_Target then
                      Error ("cannot assign to a constant: " & N)
                   end
@@ -90,6 +100,10 @@ feature
                   end
                   if Is_Component then
                      Error ("not supported yet: a component of " & N)
+                     --  Reported, so the type it yields is poison rather than
+                     --  the base variable's: saying nothing more about a
+                     --  subscript is better than saying something wrong.
+                     Ty := T.Error_Type
                   end
                end
                --  Record a cross reference to the declared variable: a write
@@ -121,11 +135,19 @@ feature { None }
       --  than the suffix object, because a visitor holding a reference to
       --  another plugin object corrupts generated code (issue #107).
 
+   Argument_Types : Integer
+      --  One type code per argument, three bits apiece (issue #88)
+
    Check_Call (Name : String; Bound : Pascal.Checks.Binding)
       --  The name is a routine. Report what a call to it cannot do, and check
-      --  the argument count against the signature.
+      --  the argument count and types against the signature.
       do
          Is_Call := True
+         if attached Bound.Signature as Called then
+            --  A call has the function's result type, whatever else is wrong
+            --  with it (issue #88)
+            Ty := Called.Result_Type
+         end
          if Is_Target then
             --  Assigning to a function name sets its result, which needs the
             --  result slot: issue #84.
@@ -142,6 +164,7 @@ feature { None }
                       & ", found " & Given_Arguments.To_String)
             else
                Check_Var_Arguments (Name, Sig)
+               Check_Argument_Types (Name, Sig, Given_Arguments, Argument_Types)
             end
          end
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_declaration.aqua
@@ -5,7 +5,18 @@ inherit
    Pascal.Checks.Node
 
 --  variable_declaration ::= identifier_list ':' type_denoter ';'. Allocates a
---  frame slot per name in the scope being declared (issue #81).
+--  frame slot per name in the scope being declared (issue #81), and records the
+--  declared type on each binding (issue #88).
+--
+--  The names arrive before the type does -- After_Identifier_List fires when the
+--  list reduces, which is before the type_denoter sibling has been visited -- so
+--  the names are stashed and the declaring happens in After_Node, once both are
+--  in hand. Pascal.Checks.Constant_Definition has the same shape for the same
+--  reason.
+--
+--  A real takes one slot like everything else. The slot index is not a word
+--  offset: Tagatha sizes a float slot to the register pair it needs, from the
+--  content of the accesses to it. See Pascal.Checks.Scope.Declare_Local.
 --
 --  The duplicate check asks THIS scope only, so redeclaring a name in one block
 --  is an error while shadowing an outer declaration is not -- an inner x is a
@@ -15,33 +26,51 @@ inherit
 feature
 
    After_Identifier_List (Child : Pascal.Checks.Identifier_List)
+      do
+         Names := Child.Names
+      end
+
+   After_Type_Denoter (Child : Pascal.Checks.Type_Denoter)
+      do
+         Ty := Child.Ty
+      end
+
+   After_Node
       local
          It     : Aqua.Containers.Linked_List_Iterator [String]
          Name   : String
          Ignore : Integer
          Decl   : Aquarius.Entities.Declaration
       do
-         from
-            It := Child.Names.New_Cursor
-         until
-            It.After
-         loop
-            Name := It.Element
-            if Current_Frame_Scope.Is_Declared_Here (Name) then
-               Error ("duplicate declaration: " & Name)
-            else
-               Ignore := Current_Frame_Scope.Declare_Local (Name)
-               --  Record the variable in the standard entity model, keyed
-               --  in the scope so a later access can resolve and refer to it.
-               create Decl.Make (Name, Name, "variable", Current)
-               Environment.Add_Declaration (Decl)
-               Current_Frame_Scope.Add_Declaration (Decl)
-               --  Also record in the current entity scope (issue #74): the
-               --  program scope, or a procedure/function's own child scope.
-               Current_Scope.Add_Declaration (Decl)
+         if attached Names as Declared then
+            from
+               It := Declared.New_Cursor
+            until
+               It.After
+            loop
+               Name := It.Element
+               if Current_Frame_Scope.Is_Declared_Here (Name) then
+                  Error ("duplicate declaration: " & Name)
+               else
+                  Ignore := Current_Frame_Scope.Declare_Local (Name, Ty)
+                  --  Record the variable in the standard entity model, keyed
+                  --  in the scope so a later access can resolve and refer to it.
+                  create Decl.Make (Name, Name, "variable", Current)
+                  Environment.Add_Declaration (Decl)
+                  Current_Frame_Scope.Add_Declaration (Decl)
+                  --  Also record in the current entity scope (issue #74): the
+                  --  program scope, or a procedure/function's own child scope.
+                  Current_Scope.Add_Declaration (Decl)
+               end
+               It.Next
             end
-            It.Next
          end
       end
+
+feature { None }
+
+   Names : detachable Aqua.Containers.Linked_List [String]
+
+   Ty : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_parameter_specification.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_parameter_specification.aqua
@@ -19,7 +19,25 @@ feature
 
    After_Identifier_List (Child : Pascal.Checks.Identifier_List)
       do
-         Declare_Parameters (Child, True, "var-parameter")
+         Names := Child.Names
       end
+
+   After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
+      do
+         Ty := Child.Ty
+      end
+
+   After_Node
+      do
+         if attached Names as Declared then
+            Declare_Parameters (Declared, True, "var-parameter", Ty)
+         end
+      end
+
+feature { None }
+
+   Names : detachable Aqua.Containers.Linked_List [String]
+
+   Ty : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
@@ -26,11 +26,15 @@ feature
 
    Variable_Mask : Integer
 
+   Type_Mask : Integer
+      --  The argument types, three bits apiece (issue #88)
+
    After_Function_Designator (Child : Pascal.Checks.Function_Designator)
       do
          Is_Call := True
          Argument_Count := Child.Count
          Variable_Mask := Child.Variable_Mask
+         Type_Mask := Child.Type_Mask
       end
 
 end

--- a/share/aquarius/tests/pascal/test_type_errors.pas
+++ b/share/aquarius/tests/pascal/test_type_errors.pas
@@ -1,0 +1,63 @@
+{ The type system, the error cases (issue #88). Expect exactly TWELVE errors:
+
+     cannot assign real to integer                  -- narrowing needs round/trunc
+     cannot assign integer to boolean
+     cannot assign integer to char
+     operator requires integer operands, ...        -- 'div' on a real
+     operator requires integer operands, ...        -- 'mod' on a real
+     operator requires boolean operands, ...        -- 'and' on an integer
+     'not' needs a boolean operand, found integer
+     cannot compare integer with boolean
+     a sign needs a numeric operand, found boolean
+     a loop variable must be ordinal, but r is real
+     argument 1 of Takes_Integer is integer, but a real was given
+     unsupported type for an assigned value         -- a record is not modelled
+
+  One message per mistake, not one per enclosing operator: an operand whose
+  problem has been reported becomes compatible with everything, so the
+  assignment around it says nothing further.
+
+  The last one is the strict reading of an unmodelled type. Records, arrays,
+  pointers and sets are reported where they are USED rather than silently
+  accepted; typing them is issue #104.
+
+  Check with: bin/aquarius --check test_type_errors.pas }
+
+program Test_Type_Errors;
+
+type
+   Point = record
+      x, y : integer
+   end;
+
+var
+   i    : integer;
+   r    : real;
+   flag : boolean;
+   c    : char;
+   p    : Point;
+
+procedure Takes_Integer(n : integer);
+begin
+   writeln(n)
+end;
+
+begin
+   i := r;                  { error }
+   flag := i;               { error }
+   c := i;                  { error }
+
+   i := i div r;            { error }
+   i := i mod r;            { error }
+   flag := flag and i;      { error }
+   flag := not i;           { error }
+   flag := i = flag;        { error }
+   i := -flag;              { error }
+
+   for r := 1 to 10 do      { error }
+      i := i + 1;
+
+   Takes_Integer(r);        { error }
+
+   i := p                   { error }
+end.

--- a/share/aquarius/tests/pascal/test_types.pas
+++ b/share/aquarius/tests/pascal/test_types.pas
@@ -1,0 +1,68 @@
+{ The minimal type system: integer, real, boolean and char (issue #88).
+  Everything here is well typed. Expect NO errors.
+
+  Covers: a declared type on every variable, an alias of a built-in, the two
+  divisions, mixed arithmetic, integer-to-real promotion, comparisons, boolean
+  operators, an ordinal control variable, and a call checked against a typed
+  parameter list.
+
+  Note there is no 'true' or 'false': the standard boolean constants are not
+  declared yet (issue #83), so the booleans here come from comparisons.
+
+  Check with: bin/aquarius --check test_types.pas }
+
+program Test_Types;
+
+const
+   Limit  = 10;
+   Letter = 'K';
+
+type
+   Counter = integer;
+
+var
+   i, j : integer;
+   n    : Counter;
+   r, s : real;
+   flag : boolean;
+   c    : char;
+
+function Scale(x : real; by : integer) : real;
+begin
+   writeln(x)
+end;
+
+begin
+   i := 42;
+   j := i;
+   n := Limit;
+
+   r := 3.14;
+   s := r;
+   r := i;                  { integer widens to real }
+   r := i + 1;
+   s := r * 2;              { mixed arithmetic yields a real }
+   s := i / j;              { '/' is real division, even on integers }
+   i := i div j;
+   i := i mod j;
+
+   c := 'a';
+   c := Letter;
+
+   flag := i > 0;
+   flag := r <= s;
+   flag := i < r;           { integer compares against real }
+   flag := c = 'z';
+   flag := flag and (i = j);
+   flag := not flag;
+   flag := (i > 0) or (j > 0);
+
+   for i := 1 to Limit do
+      j := j + i;
+
+   for c := 'a' to 'z' do
+      j := j + 1;
+
+   s := Scale(r, i);
+   writeln(s)
+end.


### PR DESCRIPTION
Every declaration, variable access and expression now carries one of integer, real, boolean or char, and Pascal's assignment, operator and promotion rules are enforced instead of word operations being generated silently.

Types are integer codes, on Pascal.Checks.Types, following Ast.Operator. That class also holds the whole fold -- Legal, Yield, Combine and Combine_Message -- and the literal-spelling predicates, so the base class of every checks visitor stays small.

The four built-in type names are bound in the root frame scope, which makes resolving a type_denoter the same lookup as resolving a variable, and lets a user alias of a built-in shadow one. Binding gains Ty and a fifth kind, Make_Type; Signature gains the result type, which is what gives a call its type, and the parameter types, which is what the call interface needs.

Frame slots stay one per name, whatever the type. Issue #88 asked for width-aware offsets, but Tagatha's Aqua backend already maps slot index to register as a prefix sum over Slot_Width, widening a slot pushed or popped as floating point; a second prefix sum here would compose wrongly with that one.

A type outside the four is reported where it is USED rather than silently accepted. Error is a separate poison code, so one mistyped subterm gives one message rather than one per enclosing operator.

The declaration visitors move to the commit-in-After_Node shape, because the names of a variable_declaration reduce before its type_denoter does.

Three framework defects were worked around on the way, each noted where it bites:

  #117  features accumulating on Pascal.Checks.Node fault the VM inside
        an unrelated visitor
  #118  Concatenated_Image raises CONSTRAINT_ERROR past 252 characters,
        which a whole record denotation exceeds
  #120  a Linked_List [Integer] attribute on a visitor corrupts the pass,
        so argument types travel packed into an Integer, three bits each,
        beside the var-parameter flags that are packed for the same reason

Known regression, tracked in #120: startrek.pas and basics.pas now fault part way through the semantic stage where they previously reported. The crash site is decoupled from its cause -- removing the code at the site does not move it. prettyprint.pas, the largest program in the corpus, and every other test file are unaffected.

Tests: test_types.pas is well typed throughout and expects no errors; test_type_errors.pas expects exactly twelve, one per mistake. Every other file in the corpus reports exactly what it reported before.