### PR TITLE
Pascal.Checks: record types and field selection

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-field_designator.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-field_designator.aqua
@@ -1,0 +1,22 @@
+class
+   Pascal.Checks.Field_Designator
+
+inherit
+   Pascal.Checks.Node
+
+--  field_designator ::= '.' identifier
+--
+--  Publishes the field name (issue #125), read through the child identifier
+--  token rather than Concatenated_Image -- which would include the '.' --
+--  the same choice Pascal.Checks.Identifier_List makes for its names.
+
+feature
+
+   Name : detachable String
+
+   After_Identifier (Id : String)
+      do
+         Name := Id
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -150,10 +150,11 @@ feature
          Result := Current_Frame_Scope.Declare_Routine (Name, Sig)
       end
 
-   Declare_Parameters (Names        : Aqua.Containers.Linked_List [String]
-                       By_Reference : Boolean
-                       Category     : String
-                       Type_Code    : Integer)
+   Declare_Parameters (Names           : Aqua.Containers.Linked_List [String]
+                       By_Reference    : Boolean
+                       Category        : String
+                       Type_Code       : Integer
+                       Structure_Index : Integer)
       --  Bind each name as an argument of the routine whose scope is current
       --  (issue #82). Shared by the value and var parameter specifications,
       --  which differ only in By_Reference and Category.
@@ -183,10 +184,9 @@ feature
             else
                Ignore :=
                   Current_Frame_Scope.Declare_Argument
-                     (Name, By_Reference, Type_Code, 0)
-                  --  Structure 0: a parameter's type comes from a
-                  --  type_identifier, which cannot name a record or an array
-                  --  until #125 and #126 make one resolvable there.
+                     (Name, By_Reference, Type_Code, Structure_Index)
+                  --  Structure_Index: which record or array the parameter's
+                  --  type_identifier names, or 0 for a scalar (issue #125).
                --  Record it in the routine's signature too, so a call can be
                --  checked against it (issue #105), including its type (#88):
                --  a parameter slot's content has to be declared for the caller

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -296,6 +296,35 @@ feature  --  structures
          end
       end
 
+   Find_Field (Owner_Index : Integer; Field_Name : String)
+      : detachable Pascal.Checks.Field
+      --  The field named Field_Name (case-insensitive) belonging to the
+      --  record numbered Owner_Index, or Void if there is none (issue #125).
+      local
+         It    : Aqua.Containers.Linked_List_Iterator [Pascal.Checks.Field]
+         Key   : String
+         Found : Boolean
+      do
+         if attached Parent as P then
+            Result := P.Find_Field (Owner_Index, Field_Name)
+         else
+            Key := Field_Name.To_Lower
+            from
+               It := Fields.New_Cursor
+            until
+               It.After or else Found
+            loop
+               if It.Element.Owner = Owner_Index
+                 and then It.Element.Name.Equal (Key)
+               then
+                  Result := It.Element
+                  Found := True
+               end
+               It.Next
+            end
+         end
+      end
+
    Array_Size (Owner_Index : Integer; Element_Width : Integer) : Integer
       --  Element_Width times the product of every dimension recorded for
       --  Owner_Index, or 0 if there are none or any dimension's extent is

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-tag_field.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-tag_field.aqua
@@ -1,0 +1,21 @@
+class
+   Pascal.Checks.Tag_Field
+
+inherit
+   Pascal.Checks.Node
+
+--  tag_field ::= identifier
+--
+--  The name of a variant_part's discriminant, when it has one (issue #125 --
+--  see Pascal.Checks.Variant_Selector and Pascal.Checks.Variant_Part).
+
+feature
+
+   Name : detachable String
+
+   After_Identifier (Id : String)
+      do
+         Name := Id
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-tag_type.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-tag_type.aqua
@@ -1,0 +1,23 @@
+class
+   Pascal.Checks.Tag_Type
+
+inherit
+   Pascal.Checks.Node
+
+--  tag_type ::= type_identifier
+--
+--  The type of a variant_part's discriminant, when it has one (issue #125).
+--  Always one of the four scalars in practice -- a case selector has to be
+--  ordinal -- so only Ty is published; a tag can't itself name a record or an
+--  array.
+
+feature
+
+   Ty : Integer
+
+   After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
+      do
+         Ty := Child.Ty
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-type_denoter.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-type_denoter.aqua
@@ -18,6 +18,12 @@ inherit
 --  standalone type, a pointer -- fires no hook here and stays Unknown, which is
 --  what it is to a system that models the four scalars plus records and arrays.
 --
+--  type_identifier also carries Structure_Index (issue #125, for the parameter
+--  path which never goes through this class at all): 'Board = record ... end'
+--  binds Board as a record type, and 'x : Board' reaches it through
+--  type_identifier, not new_type -- an alias of a record or an array is exactly
+--  as structured as the thing it aliases, so this must copy both, not just Ty.
+--
 --  Reading Concatenated_Image here would answer both alternatives at once, and
 --  is how this was first written, but the image of a whole record denotation is
 --  far longer than the 252 characters the tree device can pass back to the
@@ -33,6 +39,7 @@ feature
    After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
       do
          Ty := Child.Ty
+         Structure_Index := Child.Structure_Index
       end
 
    After_New_Type (Child : Pascal.Checks.New_Type)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-type_identifier.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-type_identifier.aqua
@@ -7,15 +7,24 @@ inherit
 --  type_identifier ::= identifier
 --
 --  The type named by a parameter specification or a function's result_type,
---  neither of which goes through type_denoter (issue #88).
+--  neither of which goes through type_denoter (issue #88). Structure_Index is
+--  which record or array it names, when Ty says it is one (issue #125) -- the
+--  companion Pascal.Checks.Type_Denoter already publishes for a
+--  variable_declaration or a type_definition.
 
 feature
 
    Ty : Integer
 
+   Structure_Index : Integer
+
    After_Node
+      local
+         Name : String
       do
-         Ty := Resolve_Type_Name (Concatenated_Image)
+         Name := Concatenated_Image
+         Ty := Resolve_Type_Name (Name)
+         Structure_Index := Current_Frame_Scope.Lookup_Type_Structure (Name)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-value_parameter_specification.aqua
@@ -29,12 +29,13 @@ feature
    After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
       do
          Ty := Child.Ty
+         Structure_Index := Child.Structure_Index
       end
 
    After_Node
       do
          if attached Names as Declared then
-            Declare_Parameters (Declared, False, "parameter", Ty)
+            Declare_Parameters (Declared, False, "parameter", Ty, Structure_Index)
          end
       end
 
@@ -43,5 +44,7 @@ feature { None }
    Names : detachable Aqua.Containers.Linked_List [String]
 
    Ty : Integer
+
+   Structure_Index : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -18,8 +18,19 @@ inherit
 --  set, so that the code stage does not treat the name as storage -- it has no
 --  offset, and emitting a load for it produced a store to local slot 0.
 --
---  Structured access (a subscript, a field, a pointer dereference) is still
---  unsupported, but is now reported rather than silently ignored: issue #104.
+--  A field selection is now resolved (issue #125): the binding is looked up as
+--  soon as the name arrives, seeding a running (Ty, Structure) pair, and each
+--  field_designator suffix -- in source order -- looks its name up in that
+--  pair's record and carries on with the field's own (Ty, Structure). A
+--  subscript or a pointer dereference is still unsupported, and a field
+--  selection through a routine's result or an undeclared name is not attempted
+--  either -- both fall back to the same generic refusal as before. Is_Component
+--  is set for ANY of these, resolved or not: no code is generated for a
+--  structured access yet either way (issue #129), so the code stage's refusal
+--  is unaffected. What is new is that a RESOLVED chain publishes the right Ty,
+--  so the expression built from it type-checks correctly, and a broken one is
+--  reported precisely -- unknown field, or not a record -- instead of the one
+--  generic message every structured access used to get.
 
 feature
 
@@ -47,11 +58,12 @@ feature
    Is_Target : Boolean
 
    Ty : Integer
-      --  What this access yields (issue #88): the bound name's type, or the
-      --  result type of the function when it is a call. This is the leaf the
-      --  whole expression chain is typed from, and -- since this object is the
-      --  one the code stage receives by injection -- the type it will read to
-      --  choose a float operator (issue #87).
+      --  What this access yields (issue #88): the bound name's type, walked
+      --  through any field selections (issue #125), or the result type of the
+      --  function when it is a call. This is the leaf the whole expression
+      --  chain is typed from, and -- since this object is the one the code
+      --  stage receives by injection -- the type it will read to choose a
+      --  float operator (issue #87).
 
    Set_Target
       do
@@ -59,51 +71,69 @@ feature
       end
 
    After_Variable_Identifier (Child : Pascal.Checks.Variable_Identifier)
+      local
+         Name : String
       do
-         Nm := Child.Concatenated_Image
+         Name := Child.Concatenated_Image
+         Nm := Name
+         Bound := Current_Frame_Scope.Lookup (Name)
+         if attached Bound as Bnd then
+            if not Bnd.Is_Routine then
+               Current_Ty := Bnd.Ty
+               Current_Structure := Bnd.Structure
+               Path := Name
+            end
+         end
       end
 
    After_Variable_Suffix (Child : Pascal.Checks.Variable_Suffix)
+      local
+         Resolvable : Boolean
       do
+         if attached Bound as Bnd then
+            Resolvable := not Bnd.Is_Routine
+         end
          if Child.Is_Call then
             Has_Argument_List := True
             Given_Arguments := Child.Argument_Count
             Argument_Variables := Child.Variable_Mask
             Argument_Types := Child.Type_Mask
+         elsif Resolvable then
+            if Child.Is_Field then
+               if attached Child.Field_Name as Name then
+                  Apply_Field (Name)
+               end
+            else
+               Poison_Component
+            end
          else
+            --  A routine's result, or an undeclared name, followed by a
+            --  field/subscript/dereference: not attempted, same coarse
+            --  refusal as before this issue.
             Is_Component := True
          end
       end
 
    After_Node
       local
-         B : detachable Pascal.Checks.Binding
          T : Pascal.Checks.Types
       do
          if attached Nm as N then
-            B := Current_Frame_Scope.Lookup (N)
-            if attached B as Bound then
-               if Bound.Is_Routine then
-                  Check_Call (N, Bound)
+            if attached Bound as Bnd then
+               if Bnd.Is_Routine then
+                  Check_Call (N, Bnd)
                else
-                  Offset := Bound.Offset
-                  Is_Argument := Bound.Is_Argument
-                  By_Reference := Bound.By_Reference
-                  Is_Constant := Bound.Is_Constant
-                  Value := Bound.Value
-                  Ty := Bound.Ty
+                  Offset := Bnd.Offset
+                  Is_Argument := Bnd.Is_Argument
+                  By_Reference := Bnd.By_Reference
+                  Is_Constant := Bnd.Is_Constant
+                  Value := Bnd.Value
+                  Ty := Current_Ty
                   if Is_Constant and then Is_Target then
                      Error ("cannot assign to a constant: " & N)
                   end
                   if Has_Argument_List then
                      Error ("not a routine, so it cannot be called: " & N)
-                  end
-                  if Is_Component then
-                     Error ("not supported yet: a component of " & N)
-                     --  Reported, so the type it yields is poison rather than
-                     --  the base variable's: saying nothing more about a
-                     --  subscript is better than saying something wrong.
-                     Ty := T.Error_Type
                   end
                end
                --  Record a cross reference to the declared variable: a write
@@ -128,6 +158,29 @@ feature { None }
 
    Nm : detachable String
 
+   Bound : detachable Pascal.Checks.Binding
+      --  Resolved as soon as the name arrives, not deferred to After_Node: a
+      --  field_designator suffix needs it before After_Node ever runs (issue
+      --  #125).
+
+   Current_Ty : Integer
+      --  The type reached so far while walking field_designator suffixes,
+      --  seeded from Bound.Ty. Meaningless (never read) unless Bound is
+      --  attached and not a routine.
+
+   Current_Structure : Integer
+      --  The structure reached so far, alongside Current_Ty
+
+   Path : detachable String
+      --  Source text of the access reached so far ("shape", then
+      --  "shape.corner", ...), for precise messages. Attached exactly when
+      --  Current_Ty / Current_Structure are meaningful.
+
+   Broken : Boolean
+      --  A field selection has already failed; stop resolving further
+      --  suffixes and reporting further messages about this access, the same
+      --  way Pascal.Checks.Types.Error_Type poisons an expression.
+
    Has_Argument_List  : Boolean
    Given_Arguments    : Integer
    Argument_Variables : Integer
@@ -138,12 +191,73 @@ feature { None }
    Argument_Types : Integer
       --  One type code per argument, three bits apiece (issue #88)
 
-   Check_Call (Name : String; Bound : Pascal.Checks.Binding)
+   Apply_Field (Field_Name : String)
+      --  Resolve one field_designator against Current_Ty / Current_Structure,
+      --  advancing both to the field's, or reporting why it cannot be done
+      --  (issue #125). Called only when Bound is attached and not a routine.
+      local
+         T      : Pascal.Checks.Types
+         Rec    : Pascal.Checks.Structure
+         F      : detachable Pascal.Checks.Field
+         Is_Rec : Boolean
+      do
+         Is_Component := True
+         if not Broken then
+            if attached Path as P then
+               if T.Is_Structured (Current_Ty) and then Current_Structure > 0 then
+                  Rec := Current_Frame_Scope.Structure (Current_Structure)
+                  Is_Rec := Rec.Is_Record
+               end
+               if Is_Rec then
+                  F := Current_Frame_Scope.Find_Field (Current_Structure, Field_Name)
+                  if attached F as Found then
+                     Current_Ty := Found.Ty
+                     Current_Structure := Found.Structure
+                     Path := P & "." & Field_Name
+                  else
+                     Error ("no field " & Field_Name & " in " & P)
+                     Current_Ty := T.Error_Type
+                     Broken := True
+                  end
+               else
+                  Error ("cannot select a field of " & P & ": not a record")
+                  Current_Ty := T.Error_Type
+                  Broken := True
+               end
+            end
+         end
+      end
+
+   Poison_Component
+      --  A subscript or a pointer dereference: still unsupported (#126, and a
+      --  pointer type outside the model entirely). Same message as every
+      --  structured access used to get, but now only once per broken chain.
+      --
+      --  Current_Ty MUST be poisoned to Error_Type here, same as a failed
+      --  field selection: otherwise After_Node publishes whatever real type
+      --  the walk had reached (e.g. Structured_Type for an array), which is
+      --  not Is_Quiet, and every operator and assignment above this access
+      --  starts reporting on it too -- one unsupported subscript would
+      --  otherwise cascade into an "unsupported type" message at every use.
+      local
+         T : Pascal.Checks.Types
+      do
+         Is_Component := True
+         if not Broken then
+            if attached Path as P then
+               Error ("not supported yet: a component of " & P)
+            end
+            Current_Ty := T.Error_Type
+            Broken := True
+         end
+      end
+
+   Check_Call (Name : String; Routine_Binding : Pascal.Checks.Binding)
       --  The name is a routine. Report what a call to it cannot do, and check
       --  the argument count and types against the signature.
       do
          Is_Call := True
-         if attached Bound.Signature as Called then
+         if attached Routine_Binding.Signature as Called then
             --  A call has the function's result type, whatever else is wrong
             --  with it (issue #88)
             Ty := Called.Result_Type
@@ -152,7 +266,7 @@ feature { None }
             --  Assigning to a function name sets its result, which needs the
             --  result slot: issue #84.
             Error ("not supported yet: assignment to the result of " & Name)
-         elsif attached Bound.Signature as Sig then
+         elsif attached Routine_Binding.Signature as Sig then
             if not Sig.Is_Function then
                Error ("a procedure has no value, so it cannot be used here: "
                       & Name)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_parameter_specification.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_parameter_specification.aqua
@@ -25,12 +25,13 @@ feature
    After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
       do
          Ty := Child.Ty
+         Structure_Index := Child.Structure_Index
       end
 
    After_Node
       do
          if attached Names as Declared then
-            Declare_Parameters (Declared, True, "var-parameter", Ty)
+            Declare_Parameters (Declared, True, "var-parameter", Ty, Structure_Index)
          end
       end
 
@@ -39,5 +40,7 @@ feature { None }
    Names : detachable Aqua.Containers.Linked_List [String]
 
    Ty : Integer
+
+   Structure_Index : Integer
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
@@ -7,16 +7,19 @@ inherit
 --  variable_suffix ::= indexed_variable | field_designator | identified_variable
 --                    | function_designator
 --
---  Only the call form is understood (issue #105): a function_designator makes
---  the enclosing variable_access a call rather than a load, and carries the
---  number of arguments and which of them are bare variables. The other three --
---  subscript, field selection and pointer dereference -- are structured access,
---  issue #104, and are reported by variable_access as unsupported rather than
---  silently ignored, which is what used to happen.
+--  The call and field forms are understood. A function_designator makes the
+--  enclosing variable_access a call rather than a load, and carries the number
+--  of arguments and which of them are bare variables (issue #105). A
+--  field_designator carries the field's name (issue #125), for
+--  variable_access to resolve against the type it has reached so far. The
+--  other two -- subscript and pointer dereference -- are structured access
+--  not yet modelled (subscript is #126; a pointer type is out of the model
+--  entirely) and are reported by variable_access as unsupported, same as
+--  before this issue.
 --
---  The argument information is copied out as values rather than kept as a
---  reference to the child: a visitor holding a reference to another plugin
---  object corrupts the generated code (issue #107).
+--  The argument and field information is copied out as values rather than
+--  kept as a reference to the child: a visitor holding a reference to another
+--  plugin object corrupts the generated code (issue #107).
 
 feature
 
@@ -29,12 +32,22 @@ feature
    Type_Mask : Integer
       --  The argument types, three bits apiece (issue #88)
 
+   Is_Field : Boolean
+
+   Field_Name : detachable String
+
    After_Function_Designator (Child : Pascal.Checks.Function_Designator)
       do
          Is_Call := True
          Argument_Count := Child.Count
          Variable_Mask := Child.Variable_Mask
          Type_Mask := Child.Type_Mask
+      end
+
+   After_Field_Designator (Child : Pascal.Checks.Field_Designator)
+      do
+         Is_Field := True
+         Field_Name := Child.Name
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variant_part.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variant_part.aqua
@@ -17,28 +17,41 @@ inherit
 --  Size ends up the high water mark over all of them -- as big as its largest
 --  variant, which is what Pascal means by one.
 --
---  All this node does is remember that starting offset, on the record itself
---  (Structure.Variant_Start): each Pascal.Checks.Case_Variant then rewinds to
---  it in its OWN Before_Node. Nothing here needs a hook on variant_selector or
---  case_variant -- record_section (reached through each variant's nested
---  field_list) does the actual field-adding, found via
---  Node.Current_Structure_Index exactly as it is outside a variant_part.
+--  variant_selector's tag_field -- the discriminant -- IS added as a field
+--  here when it comes with a type (issue #125: found necessary once real
+--  programs turned up reading it directly, e.g. chess.pas's
+--  'case RMPR : boolean of ...' and then testing A.RMPR). Written as
+--  'case tag of ...' instead, with no type, it names a field declared earlier
+--  in the same field_list, so nothing is added -- adding it again would
+--  double it up, and there is no type here to give it anyway.
 --
---  variant_selector's tag_field -- the discriminant -- is NOT added as a field
---  here. Written as 'case tag : sometype of ...' it declares one; written as
---  bare 'case tag of ...' it names one already declared earlier in the same
---  field_list. Telling those apart needs more than this issue's scope asks for,
---  so the tag field itself goes unmodelled while every field inside every
---  variant is modelled fully -- a deliberate partial answer, not an oversight.
+--  Either way, Variant_Start is saved AFTER the discriminant (if one was
+--  added): each Pascal.Checks.Case_Variant rewinds Next_Offset to it in its
+--  OWN Before_Node, so the variants start past the tag rather than
+--  overlapping it. record_section (reached through each variant's nested
+--  field_list) does the fields inside the variants, found via
+--  Node.Current_Structure_Index exactly as it is outside a variant_part.
 
 feature
 
-   Before_Node
+   After_Variant_Selector (Child : Pascal.Checks.Variant_Selector)
       local
-         Rec : Pascal.Checks.Structure
+         Rec   : Pascal.Checks.Structure
+         Width : Integer
+         T     : Pascal.Checks.Types
       do
          if Current_Structure_Index > 0 then
             Rec := Current_Frame_Scope.Structure (Current_Structure_Index)
+            if Child.Has_Type then
+               if attached Child.Name as Tag_Name then
+                  Width := T.Width (Child.Ty)
+                  Current_Frame_Scope.Add_Field
+                     (Current_Structure_Index, Tag_Name, Rec.Next_Offset,
+                      Width, Child.Ty, 0)
+                  Rec.Set_Next_Offset (Rec.Next_Offset + Width)
+                  Rec.Note_Offset (Rec.Next_Offset)
+               end
+            end
             Rec.Set_Variant_Start (Rec.Next_Offset)
          end
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variant_selector.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variant_selector.aqua
@@ -1,0 +1,35 @@
+class
+   Pascal.Checks.Variant_Selector
+
+inherit
+   Pascal.Checks.Node
+
+--  variant_selector ::= tag_field [ ':' tag_type ]
+--
+--  Publishes the discriminant's name, and whether a type came with it (issue
+--  #125): 'case tag : sometype of ...' declares tag as a new field of the
+--  enclosing record, so Has_Type is True and Pascal.Checks.Variant_Part adds
+--  it; bare 'case tag of ...' names a field declared earlier in the same
+--  field_list, so Has_Type is False and nothing is added -- adding it again
+--  would double it up.
+
+feature
+
+   Name : detachable String
+
+   Ty : Integer
+
+   Has_Type : Boolean
+
+   After_Tag_Field (Child : Pascal.Checks.Tag_Field)
+      do
+         Name := Child.Name
+      end
+
+   After_Tag_Type (Child : Pascal.Checks.Tag_Type)
+      do
+         Ty := Child.Ty
+         Has_Type := True
+      end
+
+end

--- a/share/aquarius/tests/pascal/test_field_selection.pas
+++ b/share/aquarius/tests/pascal/test_field_selection.pas
@@ -1,0 +1,71 @@
+{ Field selection against the structural type model (issue #125). Expect
+  exactly THREE errors, each a deliberately broken chain -- everything else
+  here is a valid field selection and should produce nothing, which is the
+  point: a resolved field now types like any other value, read, written,
+  passed through a var parameter, or used in an operator.
+
+     no field z in p                             -- p has no such field
+     cannot select a field of i: not a record     -- i is a scalar
+     cannot assign real to integer                -- p.x is integer, ordinary
+                                                       type check on a FIELD's
+                                                       type, not a field-
+                                                       selection error
+
+  Also covers: a nested record (Segment.p1.x), a var parameter of record type
+  (Move's pt -- this used to report "not a record" until a parameter's
+  type_identifier carried its Structure_Index too), and a record with a typed
+  variant discriminant (Reading.tag, itself a real field since issue #125).
+
+  Check with: bin/aquarius --check test_field_selection.pas }
+
+program Test_Field_Selection;
+
+type
+   Point = record
+      x, y : integer
+   end;
+
+   Segment = record
+      p1, p2 : Point
+   end;
+
+   Reading = record
+      kind : integer;
+      case tag : integer of
+         0 : (whole : integer);
+         1 : (approx : real)
+   end;
+
+var
+   i  : integer;
+   r  : real;
+   p  : Point;
+   s  : Segment;
+   rd : Reading;
+
+procedure Move(var pt : Point; dx, dy : integer);
+begin
+   pt.x := pt.x + dx;
+   pt.y := pt.y + dy
+end;
+
+begin
+   p.x := 1;
+   p.y := 2;
+   i := p.x + p.y;
+
+   s.p1.x := 3;
+   s.p1.y := s.p1.x;
+
+   Move(p, 1, 1);
+
+   rd.kind := 1;
+   rd.tag := 0;
+   rd.whole := 5;
+   rd.tag := 1;
+   r := rd.approx;
+
+   i := p.z;               { error }
+   i := i.x;                { error }
+   p.x := r                { error }
+end.


### PR DESCRIPTION
Finishes #125: resolves a.b field selection against the structural type model built in #124.

Pascal.Checks.Field_Designator publishes a field name; Variable_Suffix detects it (Is_Field / Field_Name) alongside the existing call detection. Variable_Access resolves the base binding as soon as the name arrives instead of deferring to After_Node, then walks suffixes in source order, carrying a running (Ty, Structure) pair through each field_designator via a new Scope.Find_Field lookup -- reporting "no field f in path" or "cannot select a field of path: not a record" precisely, instead of the one generic "not supported yet: a component of" every structured access used to get. A subscript or a pointer dereference still gets that generic message and poisons the chain, same as before this issue (#126 and pointers respectively).

Two real gaps surfaced and fixed along the way, both pre-existing since #124:

- Pascal.Checks.Type_Denoter's type_identifier alternative copied Ty but never Structure_Index, so a variable declared through a type alias of a record ("Board = record ... end; x : Board") silently lost its structure.
- A parameter's type_identifier never resolved Structure_Index at all (0 was hardcoded), so a var or value parameter of record type could never resolve a field of it. Pascal.Checks.Type_Identifier now exposes Structure_Index, threaded through Node.Declare_Parameters and both parameter specifications.

Also models a variant record's discriminant as a real field when it carries a type ("case tag : sometype of ..."), extending #124's deliberate choice to leave it unmodelled -- found necessary once chess.pas turned up reading one directly (Pascal.Checks.Variant_Selector / Tag_Field / Tag_Type; Variant_Part now adds the field and anchors Variant_Start after it, rather than in Before_Node).

Verified: pl0 unchanged at 382; prettyprint/basics/startrek/chess drop from 633/452/357/2562 to 615/437/327/2534 as field selections that used to be one generic message now either resolve silently or get a precise one; aqua suite 63/63; full test_*.pas suite unaffected. Added test_field_selection.pas: nested records, a var parameter of record type, the variant discriminant, and the three deliberately-broken chains (unknown field, not a record, and a resolved field's type still driving ordinary type checking) -- exactly three diagnostics.

Found but out of scope, filed as #134: a parser ambiguity between a set constructor's ".." and field_designator's "." occasionally attaches a phantom field selection to a range's lower bound.