### PR TITLE
Pascal.Checks: array types and subscripts

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-index_expression.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-index_expression.aqua
@@ -1,0 +1,21 @@
+class
+   Pascal.Checks.Index_Expression
+
+inherit
+   Pascal.Checks.Node
+
+--  index_expression ::= expression
+--
+--  A pure relay (issue #126): publishes the subscript expression's type for
+--  Pascal.Checks.Indexed_Variable to collect, in source order.
+
+feature
+
+   Ty : Integer
+
+   After_Expression (Child : Pascal.Checks.Expression)
+      do
+         Ty := Child.Ty
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-indexed_variable.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-indexed_variable.aqua
@@ -1,0 +1,28 @@
+class
+   Pascal.Checks.Indexed_Variable
+
+inherit
+   Pascal.Checks.Node
+
+--  indexed_variable ::= '[' < index_expression / ',' > ']'
+--
+--  Collects the subscript expressions' types in source order (issue #126), for
+--  Pascal.Checks.Variable_Access to check against the array it applies to --
+--  both how many there are, and each one's type. A real Linked_List rather
+--  than a packed mask: the #107/#120 reasons for packing no longer hold once
+--  #131 (the actual cause) was fixed, and #124's own model already uses real
+--  lists for exactly this shape of data.
+
+feature
+
+   Count : Integer
+
+   Types : Aqua.Containers.Linked_List [Integer]
+
+   After_Index_Expression (Child : Pascal.Checks.Index_Expression)
+      do
+         Count := Count + 1
+         Types.Append (Child.Ty)
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -325,6 +325,54 @@ feature  --  structures
          end
       end
 
+   Dimension_Count (Owner_Index : Integer) : Integer
+      --  How many dimensions the array numbered Owner_Index has (issue #126)
+      local
+         It : Aqua.Containers.Linked_List_Iterator [Pascal.Checks.Bounds]
+      do
+         if attached Parent as P then
+            Result := P.Dimension_Count (Owner_Index)
+         else
+            from
+               It := Dimensions.New_Cursor
+            until
+               It.After
+            loop
+               if It.Element.Owner = Owner_Index then
+                  Result := Result + 1
+               end
+               It.Next
+            end
+         end
+      end
+
+   Dimension (Owner_Index : Integer; Which : Integer) : Pascal.Checks.Bounds
+      --  The Which-th (1-based) dimension of the array numbered Owner_Index,
+      --  in declaration order (issue #126). The caller is expected to have
+      --  checked Which against Dimension_Count first.
+      local
+         It  : Aqua.Containers.Linked_List_Iterator [Pascal.Checks.Bounds]
+         At  : Integer
+      do
+         if attached Parent as P then
+            Result := P.Dimension (Owner_Index, Which)
+         else
+            from
+               It := Dimensions.New_Cursor
+            until
+               It.After or else At = Which
+            loop
+               if It.Element.Owner = Owner_Index then
+                  At := At + 1
+                  if At = Which then
+                     Result := It.Element
+                  end
+               end
+               It.Next
+            end
+         end
+      end
+
    Array_Size (Owner_Index : Integer; Element_Width : Integer) : Integer
       --  Element_Width times the product of every dimension recorded for
       --  Owner_Index, or 0 if there are none or any dimension's extent is

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -18,18 +18,20 @@ inherit
 --  set, so that the code stage does not treat the name as storage -- it has no
 --  offset, and emitting a load for it produced a store to local slot 0.
 --
---  A field selection is now resolved (issue #125): the binding is looked up as
---  soon as the name arrives, seeding a running (Ty, Structure) pair, and each
---  field_designator suffix -- in source order -- looks its name up in that
---  pair's record and carries on with the field's own (Ty, Structure). A
---  subscript or a pointer dereference is still unsupported, and a field
---  selection through a routine's result or an undeclared name is not attempted
---  either -- both fall back to the same generic refusal as before. Is_Component
---  is set for ANY of these, resolved or not: no code is generated for a
---  structured access yet either way (issue #129), so the code stage's refusal
---  is unaffected. What is new is that a RESOLVED chain publishes the right Ty,
---  so the expression built from it type-checks correctly, and a broken one is
---  reported precisely -- unknown field, or not a record -- instead of the one
+--  A field selection (issue #125) and a subscript (issue #126) are both
+--  resolved now: the binding is looked up as soon as the name arrives, seeding
+--  a running (Ty, Structure) pair, and each field_designator or
+--  indexed_variable suffix -- in source order -- resolves against that pair
+--  and carries on with the field's, or the element's, own (Ty, Structure). A
+--  pointer dereference is still unsupported (outside the model entirely), and
+--  a field/subscript through a routine's result or an undeclared name is not
+--  attempted either -- both fall back to the same generic refusal as before.
+--  Is_Component is set for ANY of these, resolved or not: no code is
+--  generated for a structured access yet either way (issue #129), so the code
+--  stage's refusal is unaffected. What is new is that a RESOLVED chain
+--  publishes the right Ty, so the expression built from it type-checks
+--  correctly, and a broken one is reported precisely -- unknown field, not a
+--  record, wrong number of subscripts, not an array -- instead of the one
 --  generic message every structured access used to get.
 
 feature
@@ -102,6 +104,10 @@ feature
             if Child.Is_Field then
                if attached Child.Field_Name as Name then
                   Apply_Field (Name)
+               end
+            elsif Child.Is_Index then
+               if attached Child.Index_Types as Types then
+                  Apply_Index (Child.Index_Count, Types)
                end
             else
                Poison_Component
@@ -228,10 +234,98 @@ feature { None }
          end
       end
 
+   Apply_Index (Given : Integer; Types : Aqua.Containers.Linked_List [Integer])
+      --  Resolve one indexed_variable against Current_Ty / Current_Structure,
+      --  advancing both to the array's element, or reporting why it cannot be
+      --  done (issue #126). Called only when Bound is attached and not a
+      --  routine. Given is how many subscript expressions were written;
+      --  Types is their types, in order.
+      local
+         T      : Pascal.Checks.Types
+         Arr    : Pascal.Checks.Structure
+         Is_Arr : Boolean
+         Dims   : Integer
+      do
+         Is_Component := True
+         if not Broken then
+            if attached Path as P then
+               if T.Is_Structured (Current_Ty) and then Current_Structure > 0 then
+                  Arr := Current_Frame_Scope.Structure (Current_Structure)
+                  Is_Arr := Arr.Is_Array
+               end
+               if Is_Arr then
+                  Dims := Current_Frame_Scope.Dimension_Count (Current_Structure)
+                  if Given < Dims then
+                     Error ("not enough subscripts for " & P & ": " & P
+                            & " needs " & Dims.To_String & ", found "
+                            & Given.To_String)
+                     Current_Ty := T.Error_Type
+                     Broken := True
+                  elsif Given > Dims then
+                     Error ("too many subscripts for " & P & ": " & P
+                            & " needs " & Dims.To_String & ", found "
+                            & Given.To_String)
+                     Current_Ty := T.Error_Type
+                     Broken := True
+                  else
+                     Check_Index_Types (P, Types)
+                     Current_Ty := Arr.Element_Ty
+                     Current_Structure := Arr.Element_Structure
+                     Path := P & "[]"
+                  end
+               else
+                  Error ("cannot subscript " & P & ": not an array")
+                  Current_Ty := T.Error_Type
+                  Broken := True
+               end
+            end
+         end
+      end
+
+   Check_Index_Types (P : String; Types : Aqua.Containers.Linked_List [Integer])
+      --  Each subscript expression must be ordinal, and assignable to its
+      --  dimension's index type (issue #126). Reported but not poisoned:
+      --  unlike a wrong subscript COUNT or a non-array base, a wrong index
+      --  TYPE does not stop the chain -- 'matrix[i].field' should still
+      --  resolve the field even if i's type is slightly off, the same way a
+      --  bad call argument does not stop Check_Argument_Types checking the
+      --  rest.
+      local
+         It      : Aqua.Containers.Linked_List_Iterator [Integer]
+         T       : Pascal.Checks.Types
+         Dim     : Pascal.Checks.Bounds
+         Expr_Ty : Integer
+         Which   : Integer
+      do
+         from
+            It := Types.New_Cursor
+         until
+            It.After
+         loop
+            Which := Which + 1
+            Expr_Ty := It.Element
+            if not T.Is_Quiet (Expr_Ty) then
+               if not T.Is_Ordinal (Expr_Ty) then
+                  Error ("subscript " & Which.To_String & " of " & P
+                         & " must be ordinal, but found " & T.Name (Expr_Ty))
+               else
+                  Dim := Current_Frame_Scope.Dimension (Current_Structure, Which)
+                  if T.Is_Known (Dim.Ty) and then not T.Assignable (Dim.Ty, Expr_Ty)
+                  then
+                     Error ("subscript " & Which.To_String & " of " & P
+                            & " is " & T.Name (Dim.Ty) & ", but "
+                            & T.Name (Expr_Ty) & " was given")
+                  end
+               end
+            end
+            It.Next
+         end
+      end
+
    Poison_Component
-      --  A subscript or a pointer dereference: still unsupported (#126, and a
-      --  pointer type outside the model entirely). Same message as every
-      --  structured access used to get, but now only once per broken chain.
+      --  A pointer dereference: outside the model entirely. Same message as
+      --  every structured access used to get, but now only once per broken
+      --  chain.
       --
       --  Current_Ty MUST be poisoned to Error_Type here, same as a failed
       --  field selection: otherwise After_Node publishes whatever real type

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
@@ -7,19 +7,21 @@ inherit
 --  variable_suffix ::= indexed_variable | field_designator | identified_variable
 --                    | function_designator
 --
---  The call and field forms are understood. A function_designator makes the
---  enclosing variable_access a call rather than a load, and carries the number
---  of arguments and which of them are bare variables (issue #105). A
---  field_designator carries the field's name (issue #125), for
---  variable_access to resolve against the type it has reached so far. The
---  other two -- subscript and pointer dereference -- are structured access
---  not yet modelled (subscript is #126; a pointer type is out of the model
---  entirely) and are reported by variable_access as unsupported, same as
---  before this issue.
+--  The call, field and subscript forms are all understood now. A
+--  function_designator makes the enclosing variable_access a call rather than
+--  a load, and carries the number of arguments and which of them are bare
+--  variables (issue #105). A field_designator carries the field's name (issue
+--  #125). An indexed_variable carries how many subscript expressions were
+--  written and each one's type, in order (issue #126). variable_access
+--  resolves whichever of these against the type it has reached so far. The
+--  remaining alternative -- a pointer dereference -- is outside the model
+--  entirely and is reported by variable_access as unsupported, same as
+--  before either issue.
 --
---  The argument and field information is copied out as values rather than
---  kept as a reference to the child: a visitor holding a reference to another
---  plugin object corrupts the generated code (issue #107).
+--  The argument, field and subscript information is copied out as values
+--  rather than kept as a reference to the child: a visitor holding a
+--  reference to another plugin object corrupts the generated code (issue
+--  #107).
 
 feature
 
@@ -36,6 +38,12 @@ feature
 
    Field_Name : detachable String
 
+   Is_Index : Boolean
+
+   Index_Count : Integer
+
+   Index_Types : detachable Aqua.Containers.Linked_List [Integer]
+
    After_Function_Designator (Child : Pascal.Checks.Function_Designator)
       do
          Is_Call := True
@@ -48,6 +56,13 @@ feature
       do
          Is_Field := True
          Field_Name := Child.Name
+      end
+
+   After_Indexed_Variable (Child : Pascal.Checks.Indexed_Variable)
+      do
+         Is_Index := True
+         Index_Count := Child.Count
+         Index_Types := Child.Types
       end
 
 end

--- a/share/aquarius/tests/pascal/test_subscripts.pas
+++ b/share/aquarius/tests/pascal/test_subscripts.pas
@@ -1,0 +1,52 @@
+{ Subscript resolution against the structural type model (issue #126). Expect
+  exactly FIVE errors, each a deliberately broken subscript -- everything else
+  here is valid and should produce nothing: a one-dimensional array, a
+  two-dimensional one written 'g[i, j]', an array of records (chaining a
+  subscript into a field selection), and a non-integer index type.
+
+     too many subscripts for r         -- r is one-dimensional
+     not enough subscripts for g       -- g is two-dimensional
+     subscript 1 of r must be ordinal  -- a real index
+     subscript 1 of ls is char, but integer was given
+     cannot subscript i: not an array  -- i is a scalar
+
+  Check with: bin/aquarius --check test_subscripts.pas }
+
+program Test_Subscripts;
+
+type
+   Row = array [1 .. 5] of integer;
+   Grid = array [1 .. 2, 1 .. 3] of integer;
+   Letters = array ['a' .. 'z'] of integer;
+   Point = record
+      x, y : integer
+   end;
+   Points = array [1 .. 3] of Point;
+
+var
+   i, j : integer;
+   r    : Row;
+   g    : Grid;
+   ls   : Letters;
+   ps   : Points;
+   c    : char;
+
+begin
+   r[1] := 10;
+   i := r[2] + r[3];
+
+   g[1, 2] := 5;
+   i := g[2, 1];
+
+   ps[1].x := 1;
+   ps[2].y := ps[1].x;
+
+   c := 'a';
+   ls[c] := 7;
+
+   i := r[1, 2];            { error }
+   i := g[1];                { error }
+   i := r[3.14];             { error }
+   i := ls[5];               { error }
+   i := i[1]                 { error }
+end.


### PR DESCRIPTION
Finishes #126: resolves a[i] subscripting against the structural type model, the sibling of #125's field selection.

Pascal.Checks.Index_Expression relays a subscript expression's type; Indexed_Variable collects them in source order (Count, and a real Linked_List [Integer] of types -- not a packed mask, since the #107/#120 reasons for packing no longer apply once #131 was fixed, and #124 already established real lists for exactly this shape of data). Variable_Suffix detects it (Is_Index / Index_Count / Index_Types) alongside the existing call and field detection.

Variable_Access's walk (already resolving field selections since #125) now also resolves a subscript: Apply_Index checks the base is an array, checks the subscript COUNT against Scope.Dimension_Count (a mismatch is one of two distinct messages -- "too many" or "not enough" -- since Pascal writes galaxy[i, j] and galaxy[i][j] for the same thing, so both directions are worth telling apart), then Check_Index_Types checks each index expression is ordinal and assignable to its dimension's index type via Scope.Dimension, reporting but not poisoning a wrong index TYPE -- matrix[i].field should still resolve the field even if i's type is slightly off, the same way a bad call argument does not stop the rest of Check_Argument_Types. On success the walk continues with the array's element (Ty, Structure), so a subscript chains into a further field selection or subscript exactly like #125's fields do.

A pointer dereference remains the one alternative Poison_Component still covers -- outside the model entirely.

Verified: aqua suite 63/63, full test_*.pas suite unaffected (including test_field_selection.pas's three errors, untouched). The five benchmarks all drop as subscripts that used to be one generic "component of" message either resolve silently or get a precise one instead: pl0 382->316, prettyprint 615->569, basics 437->267, startrek 327->306, chess 2534->2430. Spot-checked several of the drops directly against source (plain char-array subscripts resolving to nothing; array-of-enum elements correctly now reporting "unsupported type" instead of a generic message, the same honesty #125 surfaced for CURRCHAR/NEXTCHAR) to confirm these are real resolutions, not suppressed errors.

Added test_subscripts.pas: a 1-D array, a 2-D array written g[i, j], an array of records (chaining a subscript into a field selection), a non-integer (char) index type, and five deliberately broken subscripts -- too many, too few, a non-ordinal index, an index of the wrong type, and subscripting a non-array -- exactly five diagnostics.