### PR TITLE
Pascal.Checks: with as a scope

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -2,7 +2,7 @@ class
    Pascal.Checks.Binding
 
 create
-   Make_Local, Make_Argument, Make_Constant, Make_Routine, Make_Type
+   Make_Local, Make_Argument, Make_Constant, Make_Routine, Make_Type, Make_With
 
 --  One name bound to one slot of the enclosing routine's frame, held by
 --  Pascal.Checks.Scope (issue #81).
@@ -35,6 +35,16 @@ create
 --  Structure says WHICH, as an index into Pascal.Checks.Scope's structure
 --  table (Structure / New_Record / New_Array). It is zero for every scalar,
 --  which is the table's "no structure" index.
+--
+--  A with binding is the sixth kind (issue #127): one per field of a with
+--  statement's record variable, in the scope it opens. Ty and Structure are
+--  the field's own -- the same pair a plain Pascal.Checks.Field carries -- so
+--  a with-bound name that is itself a record chains into a further field
+--  selection exactly like an ordinary one. Offset is the field's offset
+--  within that record, in words: not a frame slot or an argument index (there
+--  is no storage for a with binding to call its own until the record
+--  variable's base address is), but recorded now so lowering it later is
+--  narrowing the representation, not rebuilding it.
 
 feature
 
@@ -90,11 +100,24 @@ feature
          Is_Type := True
       end
 
+   Make_With (Bound_Name      : String
+              Field_Offset    : Integer
+              Type_Code       : Integer
+              Structure_Index : Integer)
+      do
+         Name := Bound_Name.To_Lower
+         Offset := Field_Offset
+         Ty := Type_Code
+         Structure := Structure_Index
+         Is_With := True
+      end
+
    Name : String
 
    Offset : Integer
       --  Frame slot for a local, argument index for an argument; both 1-based.
-      --  Meaningless for a constant, which occupies no storage.
+      --  A field's own offset within the record, in words, for a with binding
+      --  (issue #127). Meaningless for a constant, which occupies no storage.
 
    Value : Integer
       --  The value of a constant; meaningless for anything else
@@ -120,6 +143,8 @@ feature
    Is_Routine : Boolean
 
    Is_Type : Boolean
+
+   Is_With : Boolean
 
    By_Reference : Boolean
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-record_variable_list.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-record_variable_list.aqua
@@ -1,0 +1,35 @@
+class
+   Pascal.Checks.Record_Variable_List
+
+inherit
+   Pascal.Checks.Node
+
+--  record_variable_list ::= < variable_access / ',' >
+--
+--  Collects each record variable's resolved type and structure, and its
+--  source text (for messages), in source order (issue #127).
+--  Pascal.Checks.With_Statement opens one nested scope per item once the
+--  whole list has been visited -- 'with a, b do' is 'with a do with b do', so
+--  the order here is the nesting order, innermost last.
+--
+--  Three parallel lists rather than one of tuples: 2-tuples are proven in
+--  this codebase (Aqua.Containers.List_Map's entries), 3-tuples are not, and
+--  this is exactly the shape Pascal.Checks.Indexed_Variable already uses for
+--  a comparable one-per-child collection (issue #126).
+
+feature
+
+   Types : Aqua.Containers.Linked_List [Integer]
+
+   Structures : Aqua.Containers.Linked_List [Integer]
+
+   Texts : Aqua.Containers.Linked_List [String]
+
+   After_Variable_Access (Child : Pascal.Checks.Variable_Access)
+      do
+         Types.Append (Child.Ty)
+         Structures.Append (Child.Structure_Index)
+         Texts.Append (Child.Concatenated_Image)
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -176,6 +176,20 @@ feature  --  declaring
          Bindings.Append (B)
       end
 
+   Declare_With (Name            : String
+                 Field_Offset    : Integer
+                 Type_Code       : Integer
+                 Structure_Index : Integer)
+      --  Bind Name in THIS scope to a field of a with statement's record
+      --  variable (issue #127). One call per field, into the scope
+      --  Pascal.Checks.With_Statement opens for that record variable.
+      local
+         B : Pascal.Checks.Binding
+      do
+         create B.Make_With (Name, Field_Offset, Type_Code, Structure_Index)
+         Bindings.Append (B)
+      end
+
    Add_Declaration (Declaration : Aquarius.Entities.Declaration)
       do
          Declarations.Append (Declaration)
@@ -319,6 +333,55 @@ feature  --  structures
                then
                   Result := It.Element
                   Found := True
+               end
+               It.Next
+            end
+         end
+      end
+
+   Field_Count (Owner_Index : Integer) : Integer
+      --  How many fields the record numbered Owner_Index has (issue #127 --
+      --  Pascal.Checks.With_Statement declares a with binding for each)
+      local
+         It : Aqua.Containers.Linked_List_Iterator [Pascal.Checks.Field]
+      do
+         if attached Parent as P then
+            Result := P.Field_Count (Owner_Index)
+         else
+            from
+               It := Fields.New_Cursor
+            until
+               It.After
+            loop
+               if It.Element.Owner = Owner_Index then
+                  Result := Result + 1
+               end
+               It.Next
+            end
+         end
+      end
+
+   Field_At (Owner_Index : Integer; Which : Integer) : Pascal.Checks.Field
+      --  The Which-th (1-based) field of the record numbered Owner_Index, in
+      --  declaration order (issue #127). The caller is expected to have
+      --  checked Which against Field_Count first.
+      local
+         It : Aqua.Containers.Linked_List_Iterator [Pascal.Checks.Field]
+         At : Integer
+      do
+         if attached Parent as P then
+            Result := P.Field_At (Owner_Index, Which)
+         else
+            from
+               It := Fields.New_Cursor
+            until
+               It.After or else At = Which
+            loop
+               if It.Element.Owner = Owner_Index then
+                  At := At + 1
+                  if At = Which then
+                     Result := It.Element
+                  end
                end
                It.Next
             end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -67,6 +67,13 @@ feature
       --  stage receives by injection -- the type it will read to choose a
       --  float operator (issue #87).
 
+   Structure_Index : Integer
+      --  Which record or array Ty names, when it says it is one, and 0
+      --  otherwise (issue #127) -- the companion of Ty, same pair every other
+      --  structured-type-bearing class in this model publishes. What
+      --  Pascal.Checks.With_Statement reads to find the fields of a with
+      --  statement's record variable.
+
    Set_Target
       do
          Is_Target := True
@@ -135,6 +142,14 @@ feature
                   Is_Constant := Bnd.Is_Constant
                   Value := Bnd.Value
                   Ty := Current_Ty
+                  Structure_Index := Current_Structure
+                  if Bnd.Is_With then
+                     --  A with-bound name is a field of some record variable,
+                     --  not storage of its own -- the code stage must not
+                     --  emit a plain load any more than it may for a
+                     --  resolved field selection (issue #127).
+                     Is_Component := True
+                  end
                   if Is_Constant and then Is_Target then
                      Error ("cannot assign to a constant: " & N)
                   end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-with_statement.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-with_statement.aqua
@@ -1,0 +1,109 @@
+class
+   Pascal.Checks.With_Statement
+
+inherit
+   Pascal.Checks.Node
+
+--  with_statement ::= 'with' record_variable_list 'do' statement
+--
+--  Opens one nested scope per record variable, innermost last -- 'with a, b
+--  do' is 'with a do with b do' (issue #127) -- each populated with one with
+--  binding per field of that record, found via Scope.Field_Count / Field_At.
+--  A record variable that is not a record is reported and no scope is opened
+--  for it, rather than opening an empty one and then reporting every name the
+--  body uses as undeclared. Quietly skipped (no message) when its type is
+--  already poisoned -- a broken field selection or subscript in the record
+--  variable itself has already been reported once.
+--
+--  Timing matters here: record_variable_list's items are ordinary
+--  variable_access nodes and must be fully resolved -- offsets, fields,
+--  everything #125 and #126 do -- before any of THIS opens a scope, since
+--  they are read in the ENCLOSING scope, not the one they introduce
+--  ('with p do p := q' still means the outer p). That is exactly the order
+--  the tree gives for free: record_variable_list (and everything under it)
+--  finishes before After_Record_Variable_List fires, and the body statement
+--  is not visited until after that returns.
+
+feature
+
+   After_Record_Variable_List (Child : Pascal.Checks.Record_Variable_List)
+      local
+         Ty_It     : Aqua.Containers.Linked_List_Iterator [Integer]
+         Struct_It : Aqua.Containers.Linked_List_Iterator [Integer]
+         Text_It   : Aqua.Containers.Linked_List_Iterator [String]
+         T         : Pascal.Checks.Types
+         Ty        : Integer
+         Struct    : Integer
+         Text      : String
+         Rec       : Pascal.Checks.Structure
+         Is_Rec    : Boolean
+      do
+         from
+            Ty_It := Child.Types.New_Cursor
+            Struct_It := Child.Structures.New_Cursor
+            Text_It := Child.Texts.New_Cursor
+         until
+            Ty_It.After
+         loop
+            Ty := Ty_It.Element
+            Struct := Struct_It.Element
+            Text := Text_It.Element
+            Is_Rec := False
+            if T.Is_Structured (Ty) and then Struct > 0 then
+               Rec := Current_Frame_Scope.Structure (Struct)
+               Is_Rec := Rec.Is_Record
+            end
+            if Is_Rec then
+               Enter_With_Scope (Struct)
+               Opened := Opened + 1
+            elsif not T.Is_Quiet (Ty) then
+               Error ("with requires a record: " & Text & " is not a record")
+            end
+            Ty_It.Next
+            Struct_It.Next
+            Text_It.Next
+         end
+      end
+
+   After_Node
+      --  Pop exactly as many scopes as were opened: a record variable that
+      --  was not a record contributed none.
+      local
+         K : Integer
+      do
+         from
+            K := 1
+         until
+            K > Opened
+         loop
+            Leave_Scope
+            K := K + 1
+         end
+      end
+
+feature { None }
+
+   Opened : Integer
+
+   Enter_With_Scope (Structure_Index : Integer)
+      local
+         Entity_Scope : Aquarius.Entities.Scope
+         F            : Pascal.Checks.Field
+         Count        : Integer
+         N            : Integer
+      do
+         create Entity_Scope.Make
+         Enter_Scope (Entity_Scope)
+         Count := Current_Frame_Scope.Field_Count (Structure_Index)
+         from
+            N := 1
+         until
+            N > Count
+         loop
+            F := Current_Frame_Scope.Field_At (Structure_Index, N)
+            Current_Frame_Scope.Declare_With (F.Name, F.Offset, F.Ty, F.Structure)
+            N := N + 1
+         end
+      end
+
+end

--- a/share/aquarius/tests/pascal/test_with.pas
+++ b/share/aquarius/tests/pascal/test_with.pas
@@ -1,0 +1,68 @@
+{ 'with' as a scope (issue #127). Expect exactly ONE error -- everything else
+  here is a valid use of 'with' and should produce nothing.
+
+     with requires a record: i is not a record
+
+  Covers: a plain record variable, a nested record's field written through the
+  enclosing record's own with, a NESTED with ('with a, b do', which opens one
+  scope per variable, innermost last), a with-variable that is itself an
+  array element (the issue's own galaxy[i, j] example), a with-bound field
+  shadowing an outer variable of the same name, and 'with' on something that
+  is not a record -- reported once, with the body still resolving names
+  against the ENCLOSING scope rather than cascading into "undeclared".
+
+  Check with: bin/aquarius --check test_with.pas }
+
+program Test_With;
+
+type
+   Point = record
+      x, y : integer
+   end;
+
+   Segment = record
+      p1, p2 : Point;
+      len    : integer
+   end;
+
+   Points = array [1 .. 3] of Point;
+
+var
+   p  : Point;
+   s  : Segment;
+   ps : Points;
+   i  : integer;
+   x  : integer;
+
+begin
+   x := 99;
+
+   with p do
+   begin
+      x := 1;             { shadows the outer x: this is p.x }
+      y := 2
+   end;
+
+   with s do
+   begin
+      len := 10;
+      p1.x := 3;
+      p1.y := p1.x
+   end;
+
+   with s.p1, s.p2 do
+   begin
+      x := 5;              { innermost wins: s.p2.x }
+      y := x
+   end;
+
+   i := 1;
+   with ps[i] do
+   begin
+      x := 7;
+      y := 8
+   end;
+
+   with i do                { error }
+      x := 0                { the outer x again: no scope was opened }
+end.


### PR DESCRIPTION
Finishes #127: a with statement now opens a real scope, resolving every name it brings into view instead of reporting each one as undeclared.

Pascal.Checks.Record_Variable_List collects each record variable's resolved type, structure and source text, in order. Pascal.Checks.With_Statement opens one nested scope per item once the whole list has been visited -- the timing the tree gives for free, since a record variable is itself read in the ENCLOSING scope ('with p do p := q' still means the outer p) -- populating each with one Binding.Make_With per field, found via the new Scope.Field_Count / Field_At (mirroring #126's Dimension_Count / Dimension). 'with a, b do' opens two scopes, innermost last, matching 'with a do with b do': a name found in both resolves to the innermost, and a with-bound field shadows an outer variable of the same name for free, since that is what the existing innermost-first Lookup already does. A record variable that is not a record is reported once and no scope is opened for it, so the body still resolves names against the enclosing scope rather than cascading into "undeclared" for every name it uses.

A with binding is a sixth Binding kind: its Ty / Structure are the field's own, so a with-bound name that is itself a record chains into a further field selection exactly like an ordinary field does (#125), and Offset is the field's offset within the record in words -- not a frame slot, since a with binding has no storage of its own until the record variable's base address does (a future codegen issue's problem, noted on Binding and left to it). Variable_Access now also publishes Structure_Index (the companion of Ty every other structured-type-bearing class in this model already carries), which With_Statement and Record_Variable_List both need and which was the one gap left over from #125/#126 -- Variable_Access itself never had a public reason to expose it until now.

Verified: aqua suite 63/63, full test_*.pas suite unaffected. pl0/prettyprint/ startrek/chess drop from 316/569/306/2430 to 301/552/273/2298 as with-bound names that used to be "undeclared variable" now resolve (confirmed directly: "undeclared variable: klingnum" -- this issue's own worked example, straight from startrek.pas -- goes from several to zero); basics is unchanged, since it does not use with. Some of the remaining diagnostics at those same sites are "unsupported type", not this issue's doing: startrek's klingnum is declared 'digits = 0 .. maxdigit', a standalone subrange type alias, which #124 never modelled (only a subrange as an array's index_type resolves) -- a pre-existing gap now visible because the field resolves at all, the same pattern #125 and #126 each surfaced once before.

Added test_with.pas: a plain record, a nested record's field, 'with a, b do' with the shadowing that implies, a with-variable that is itself an array element (this issue's own galaxy[i, j] example), and 'with' on something that is not a record -- exactly one diagnostic, and the body still resolving its name against the outer scope rather than cascading.