### PR TITLE
Pascal.Checks: undo the packed-mask workaround from the misdiagnosed …

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter_list.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-actual_parameter_list.aqua
@@ -7,33 +7,25 @@ inherit
 --  actual_parameter_list ::= '(' < actual_parameter / ',' > ')'. The argument
 --  list of a procedure statement; Count is its arity (issue #105).
 --
---  Variable_Mask carries one bit per argument, set when that argument is a bare
---  variable: a visitor cannot hold a reference to another plugin object
---  (issue #107), and Integer has no bit operations (issue #109), so the flags
---  travel as arithmetic. Node.Mask_Holds reads it back.
---
---  Type_Mask carries the type of each argument the same way, three bits apiece
---  (issue #88). It was a Linked_List [Integer] first, which reads far better,
---  but that attribute on this class faults the VM part way through a large
---  program (issue #120). Pascal.Checks.Types.Packed_Type reads it back.
+--  Argument_Variables and Argument_Types carry, one entry per argument,
+--  whether it is a bare variable and its type (issues #105, #88). Real
+--  lists rather than a packed mask: the #107/#120 reasons for packing no
+--  longer hold once #131 (the actual cause) was fixed, and #124's own model
+--  already uses real lists for exactly this shape of data (issue #133).
 
 feature
 
    Count : Integer
 
-   Variable_Mask : Integer
+   Argument_Variables : Aqua.Containers.Linked_List [Boolean]
 
-   Type_Mask : Integer
+   Argument_Types : Aqua.Containers.Linked_List [Integer]
 
    After_Actual_Parameter (Child : Pascal.Checks.Actual_Parameter)
-      local
-         T : Pascal.Checks.Types
       do
          Count := Count + 1
-         if Child.Is_Variable then
-            Variable_Mask := Variable_Mask + Argument_Weight (Count)
-         end
-         Type_Mask := Type_Mask + Child.Ty * T.Type_Weight (Count)
+         Argument_Variables.Append (Child.Is_Variable)
+         Argument_Types.Append (Child.Ty)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-function_designator.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-function_designator.aqua
@@ -9,32 +9,24 @@ inherit
 --  but it reaches the checks stage as a variable_suffix, because that is how the
 --  grammar spells a call (issue #105).
 --
---  Which arguments are bare variables is carried as one bit per argument in
---  Variable_Mask rather than as a list, because a visitor cannot hold a
---  reference to another plugin object (issue #107) and Integer has no bit
---  operations (issue #109). Node.Mask_Holds reads it back.
-
---  Type_Mask carries the type of each argument the same way, three bits apiece
---  (issue #88). See Pascal.Checks.Actual_Parameter_List for why it is a mask
---  and not the list it should be.
+--  Argument_Variables and Argument_Types carry, one entry per argument,
+--  whether it is a bare variable and its type (issues #105, #88). Real lists
+--  rather than a packed mask, for the same reason as
+--  Pascal.Checks.Actual_Parameter_List (issue #133).
 
 feature
 
    Count : Integer
 
-   Variable_Mask : Integer
+   Argument_Variables : Aqua.Containers.Linked_List [Boolean]
 
-   Type_Mask : Integer
+   Argument_Types : Aqua.Containers.Linked_List [Integer]
 
    After_Actual_Parameter (Child : Pascal.Checks.Actual_Parameter)
-      local
-         T : Pascal.Checks.Types
       do
          Count := Count + 1
-         if Child.Is_Variable then
-            Variable_Mask := Variable_Mask + Argument_Weight (Count)
-         end
-         Type_Mask := Type_Mask + Child.Ty * T.Type_Weight (Count)
+         Argument_Variables.Append (Child.Is_Variable)
+         Argument_Types.Append (Child.Ty)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -202,47 +202,27 @@ feature
          end
       end
 
-   Argument_Weight (Index : Integer) : Integer
-      --  2 ** (Index - 1), the bit that stands for argument Index in an argument
-      --  mask. Zero beyond Argument_Mask_Limit, where the mask runs out.
+   Is_Variable_Argument (Flags : Aqua.Containers.Linked_List [Boolean]
+                         Index  : Integer) : Boolean
+      --  Whether argument Index (1-based) was a bare variable, from the list
+      --  Pascal.Checks.Actual_Parameter_List / Function_Designator built as
+      --  the arguments reduced (issue #133). False past the end of the list,
+      --  same as an out-of-range index was for the packed mask this replaced.
       local
+         It : Aqua.Containers.Linked_List_Iterator [Boolean]
          At : Integer
       do
-         if Index >= 1 and then Index <= Argument_Mask_Limit then
-            Result := 1
-            from
-               At := 1
-            until
-               At >= Index
-            loop
-               Result := Result * 2
-               At := At + 1
+         from
+            It := Flags.New_Cursor
+         until
+            It.After
+         loop
+            At := At + 1
+            if At = Index then
+               Result := It.Element
             end
+            It.Next
          end
-      end
-
-   Mask_Holds (Mask : Integer; Index : Integer) : Boolean
-      --  Whether the bit for argument Index is set in Mask.
-      --
-      --  Arithmetic rather than bit operations because Integer has neither an
-      --  and nor a shift (issue #109), and a mask rather than a list because a
-      --  visitor cannot hold a reference to another plugin object (issue #107).
-      --  Both go away when those are fixed.
-      local
-         Weight : Integer
-      do
-         Weight := Argument_Weight (Index)
-         if Weight > 0 then
-            Result := (Mask / Weight) mod 2 = 1
-         end
-      end
-
-   Argument_Mask_Limit : Integer
-      --  Arguments past the 30th are not represented: an Integer is 32 bits and
-      --  the mask is built by doubling. No Pascal call comes close, and a call
-      --  that did would simply go unchecked rather than wrong.
-      do
-         Result := 30
       end
 
    Ensure_Builtins
@@ -343,10 +323,9 @@ feature
          Result := T.Combine (Op, Left, Right)
       end
 
-   Check_Argument_Types (Name        : String
-                         Sig         : Pascal.Checks.Signature
-                         Given       : Integer
-                         Actual_Mask : Integer)
+   Check_Argument_Types (Name         : String
+                         Sig          : Pascal.Checks.Signature
+                         Actual_Types : Aqua.Containers.Linked_List [Integer])
       --  Check each actual against the parameter it is passed to (issue #88),
       --  extending the arity and var-parameter checks of issue #105. Shared by
       --  a call in an expression and a procedure statement.
@@ -358,6 +337,7 @@ feature
       --  type -- there is nowhere to put the promoted copy that a value
       --  parameter would receive.
       local
+         It     : Aqua.Containers.Linked_List_Iterator [Integer]
          Index  : Integer
          Formal : Integer
          Actual : Integer
@@ -365,12 +345,12 @@ feature
       do
          if not Sig.Is_Variadic then
             from
-               Index := 0
+               It := Actual_Types.New_Cursor
             until
-               Index >= Given
+               It.After
             loop
                Index := Index + 1
-               Actual := T.Packed_Type (Actual_Mask, Index)
+               Actual := It.Element
                Formal := Sig.Parameter_Type (Index)
                if T.Is_Known (Formal) and then not T.Is_Quiet (Actual) then
                   if Sig.Parameter_By_Reference (Index) then
@@ -386,6 +366,7 @@ feature
                             & T.Name (Actual) & " was given")
                   end
                end
+               It.Next
             end
          end
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_statement.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_statement.aqua
@@ -23,8 +23,8 @@ feature
    After_Actual_Parameter_List (Child : Pascal.Checks.Actual_Parameter_List)
       do
          Given_Arguments := Child.Count
-         Argument_Variables := Child.Variable_Mask
-         Argument_Types := Child.Type_Mask
+         Argument_Variables := Child.Argument_Variables
+         Argument_Types := Child.Argument_Types
       end
 
    After_Node
@@ -44,8 +44,7 @@ feature
                                & ", found " & Given_Arguments.To_String)
                      else
                         Check_Var_Arguments (N, Sig)
-                        Check_Argument_Types (N, Sig, Given_Arguments,
-                                              Argument_Types)
+                        Check_Argument_Types (N, Sig, Argument_Types)
                      end
                   end
                   Refer (Current, "call",
@@ -63,11 +62,11 @@ feature { None }
 
    Nm                 : detachable String
    Given_Arguments    : Integer
-   Argument_Variables : Integer
-      --  One bit per argument, set when it is a bare variable (issue #107)
+   Argument_Variables : Aqua.Containers.Linked_List [Boolean]
+      --  One entry per argument, set when it is a bare variable (issue #105)
 
-   Argument_Types : Integer
-      --  One type code per argument, three bits apiece (issue #88)
+   Argument_Types : Aqua.Containers.Linked_List [Integer]
+      --  One entry per argument, its type (issue #88)
 
    Check_Var_Arguments (Name : String; Sig : Pascal.Checks.Signature)
       --  A var parameter is passed by address, so its actual has to be something
@@ -82,7 +81,7 @@ feature { None }
             Index > Given_Arguments
          loop
             if Sig.Parameter_By_Reference (Index) then
-               if not Mask_Holds (Argument_Variables, Index) then
+               if not Is_Variable_Argument (Argument_Variables, Index) then
                   Error ("argument " & Index.To_String & " of " & Name
                          & " is a var parameter, so it needs a variable")
                end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-types.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-types.aqua
@@ -37,11 +37,13 @@ feature
       --  as an index into Pascal.Checks.Scope's structure table, never in a
       --  type code.
       --
-      --  Seven, and no eighth. Argument types travel to the signature check
-      --  packed three bits apiece (Type_Weight, Packed_Type below), so the
-      --  codes have to fit in 0 .. 7 and this is the last free value. That is
-      --  the whole reason structured types share a code rather than getting
-      --  one each.
+      --  Not the last code available: argument types used to travel to the
+      --  signature check packed three bits apiece, which capped every type
+      --  code in the system at 0 .. 7 (issue #133 unpacked that back into a
+      --  real list, so a ninth or further code is just as easy to add as this
+      --  one was). Structured types still share a single code rather than one
+      --  each -- that was never about the packing, and stays for #124's own
+      --  reasons.
       --
       --  It sits outside Is_Known deliberately, alongside Unknown_Type, so
       --  every existing check treats a whole record exactly as it did before
@@ -174,54 +176,13 @@ feature
    --  checks visitor, and features accumulated on it break the plugin VM in
    --  unrelated places (issues #107, #117), so it keeps only the thin wrapper
    --  that needs Error.
-
-   --  Argument types travel from a call's argument list to the check against
-   --  its signature packed into one Integer, three bits per argument, exactly
-   --  as the var-parameter flags travel as one bit per argument. A list would
-   --  read better, but a Linked_List attribute on THOSE visitors faults the VM
-   --  (issue #120), and Integer has no bit operations (issue #109), so the
-   --  packing is arithmetic: base 8, since the codes run 0 .. 7.
    --
-   --  0 .. 7 is now full: Structured_Type is 7. A new type code cannot be added
-   --  without changing this packing first.
-
-   Type_Slot_Limit : Integer
-      --  Arguments past the tenth are not represented: ten slots of three bits
-      --  is thirty, and an Integer is thirty-two. A call that long simply goes
-      --  unchecked rather than wrong.
-      do
-         Result := 10
-      end
-
-   Type_Weight (Index : Integer) : Integer
-      --  8 ** (Index - 1), the place value of argument Index. Zero beyond the
-      --  limit, which is what stops anything being packed there.
-      local
-         At : Integer
-      do
-         if Index >= 1 and then Index <= Type_Slot_Limit then
-            Result := 1
-            from
-               At := 1
-            until
-               At >= Index
-            loop
-               Result := Result * 8
-               At := At + 1
-            end
-         end
-      end
-
-   Packed_Type (Mask : Integer; Index : Integer) : Integer
-      --  The code packed at Index, or No_Type past the limit
-      local
-         Weight : Integer
-      do
-         Weight := Type_Weight (Index)
-         if Weight > 0 then
-            Result := (Mask / Weight) mod 8
-         end
-      end
+   --  Argument types travel from a call's argument list to the check against
+   --  its signature as a real Linked_List [Integer] (Pascal.Checks.Node.
+   --  Check_Argument_Types reads it). They used to travel packed into one
+   --  Integer, three bits per argument, base 8 since the codes ran 0 .. 7 --
+   --  a cap that left no room for an eighth type code. Issue #133 undid the
+   --  packing once #131, its actual cause, was fixed.
 
    Legal (Op : Integer; Left : Integer; Right : Integer) : Boolean
       --  Whether the operator accepts these two operand types. Only ever asked

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -105,8 +105,8 @@ feature
          if Child.Is_Call then
             Has_Argument_List := True
             Given_Arguments := Child.Argument_Count
-            Argument_Variables := Child.Variable_Mask
-            Argument_Types := Child.Type_Mask
+            Argument_Variables := Child.Argument_Variables
+            Argument_Types := Child.Argument_Types
          elsif Resolvable then
             if Child.Is_Field then
                if attached Child.Field_Name as Name then
@@ -204,13 +204,11 @@ feature { None }
 
    Has_Argument_List  : Boolean
    Given_Arguments    : Integer
-   Argument_Variables : Integer
-      --  One bit per argument, set when it is a bare variable. A mask rather
-      --  than the suffix object, because a visitor holding a reference to
-      --  another plugin object corrupts generated code (issue #107).
+   Argument_Variables : Aqua.Containers.Linked_List [Boolean]
+      --  One entry per argument, set when it is a bare variable (issue #105).
 
-   Argument_Types : Integer
-      --  One type code per argument, three bits apiece (issue #88)
+   Argument_Types : Aqua.Containers.Linked_List [Integer]
+      --  One entry per argument, its type (issue #88)
 
    Apply_Field (Field_Name : String)
       --  Resolve one field_designator against Current_Ty / Current_Structure,
@@ -387,7 +385,7 @@ feature { None }
                       & ", found " & Given_Arguments.To_String)
             else
                Check_Var_Arguments (Name, Sig)
-               Check_Argument_Types (Name, Sig, Given_Arguments, Argument_Types)
+               Check_Argument_Types (Name, Sig, Argument_Types)
             end
          end
       end
@@ -404,7 +402,7 @@ feature { None }
             Index > Given_Arguments
          loop
             if Sig.Parameter_By_Reference (Index) then
-               if not Mask_Holds (Argument_Variables, Index) then
+               if not Is_Variable_Argument (Argument_Variables, Index) then
                   Error ("argument " & Index.To_String & " of " & Name
                          & " is a var parameter, so it needs a variable")
                end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_suffix.aqua
@@ -29,10 +29,9 @@ feature
 
    Argument_Count : Integer
 
-   Variable_Mask : Integer
+   Argument_Variables : Aqua.Containers.Linked_List [Boolean]
 
-   Type_Mask : Integer
-      --  The argument types, three bits apiece (issue #88)
+   Argument_Types : Aqua.Containers.Linked_List [Integer]
 
    Is_Field : Boolean
 
@@ -48,8 +47,8 @@ feature
       do
          Is_Call := True
          Argument_Count := Child.Count
-         Variable_Mask := Child.Variable_Mask
-         Type_Mask := Child.Type_Mask
+         Argument_Variables := Child.Argument_Variables
+         Argument_Types := Child.Argument_Types
       end
 
    After_Field_Designator (Child : Pascal.Checks.Field_Designator)


### PR DESCRIPTION
…#131 (#133)

Variable_Mask/Type_Mask packed each call argument's variable-flag and type code into an Integer (one bit and three bits per argument respectively) because a Linked_List attribute on a visitor was believed to corrupt the semantic pass (#107, #120). That was actually #131, a loader relocation bug, now fixed -- confirmed by rerunning #117 and #120's exact repros clean against the fixed VM.

Actual_Parameter_List, Function_Designator, Variable_Suffix, Variable_Access and Procedure_Statement now carry Argument_Variables and Argument_Types as real Linked_List [Boolean] / Linked_List [Integer], mirroring the pattern #126 already used for Indexed_Variable.Types. Node.Check_Argument_Types iterates the list directly instead of unpacking a mask, and the now-dead Argument_Weight/Mask_Holds/Argument_Mask_Limit (Node) and Type_Weight/Packed_Type/Type_Slot_Limit (Types) are gone.

The type-code packing capped every Pascal.Checks.Types code at 0 .. 7, with Structured_Type already the last free value -- an eighth code (enumerated, file, ...) had nowhere to go without widening the packing first. Removing it removes that ceiling.

Verified byte-identical --check output before/after on all 20 dedicated Pascal unit tests, the four largest real-world corpus files (pl0, startrek, basics, prettyprint), and all 14 Programming via Pascal examples, plus identical --code-trigger output on two call-heavy fixtures.

The second candidate in #133 -- giving Structure/Field/Bounds their own owned lists instead of a flat table on Scope -- stays out of scope, as the issue itself says: it deserves its own pass.