### PR TITLE
Pascal.Checks: support for enumerated types (#139)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -17,7 +17,10 @@ create
 --  A constant binds to a value rather than to storage (issue #103): it has no
 --  offset in either space, and a use of it generates the literal instead of a
 --  load. That is also why a constant works where a value is needed before the
---  program runs, as in array [1 .. maxpgm].
+--  program runs, as in array [1 .. maxpgm]. An enumerated type's values are
+--  constants too (issue #139): red, green and blue bind exactly this way, with
+--  Structure saying which enum they belong to, same as a structured constant
+--  would if this model had one.
 --
 --  Name is stored lower-cased, because Pascal is case-insensitive; compare it
 --  with String.Equal rather than '=', which is reference equality inside a
@@ -73,14 +76,16 @@ feature
          Structure := Structure_Index
       end
 
-   Make_Constant (Bound_Name : String
-                  Constant_Value : Integer
-                  Type_Code : Integer)
+   Make_Constant (Bound_Name      : String
+                  Constant_Value  : Integer
+                  Type_Code       : Integer
+                  Structure_Index : Integer)
       do
          Name := Bound_Name.To_Lower
          Value := Constant_Value
          Is_Constant := True
          Ty := Type_Code
+         Structure := Structure_Index
       end
 
    Make_Routine (Bound_Name : String; Routine : Pascal.Checks.Signature)
@@ -129,9 +134,9 @@ feature
 
    Structure : Integer
       --  Index into Pascal.Checks.Scope's structure table when Ty is
-      --  Structured_Type, and 0
-      --  otherwise (issue #124). Which record or array, as opposed to Ty, which
-      --  says only that it is one.
+      --  Structured_Type (issue #124) or Enumerated_Type (issue #139), and 0
+      --  otherwise. Which record, array or enum, as opposed to Ty, which says
+      --  only that it is one.
 
    Signature : detachable Pascal.Checks.Signature
       --  What the routine takes, when Is_Routine; Void otherwise

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-bounds.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-bounds.aqua
@@ -13,12 +13,13 @@ create
 --  common 'array [1 .. maxpgm] of ...' modellable rather than opaque.
 --
 --  Is_Known is False when a bound could not be evaluated, or when the index is
---  a type name rather than a subrange ('array [colour] of ...', an enumerated
---  index -- enumerated types are not modelled). Length is then 0, and the
---  enclosing array's Size is 0 with it. A dimension count is still recorded,
---  which is the part a subscript check actually needs (issue #126): how many
---  subscripts the array takes is known even when how many elements it has is
---  not.
+--  a type name that is neither a subrange nor an enumerated type (issue #139
+--  made the latter Is_Known too, via Pascal.Checks.Ordinal_Type -- 'array
+--  [colour] of ...' now has a real Length, colour's declared value count).
+--  When it IS False, Length is 0, and the enclosing array's Size is 0 with it.
+--  A dimension count is still recorded, which is the part a subscript check
+--  actually needs (issue #126): how many subscripts the array takes is known
+--  even when how many elements it has is not.
 --
 --  Index_Ty is what a subscript expression must be assignable to.
 --

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-constant_definition.aqua
@@ -40,7 +40,7 @@ feature
                Error ("duplicate declaration: " & N)
             else
                if Have_Value then
-                  Current_Frame_Scope.Declare_Constant (N, Value, Ty)
+                  Current_Frame_Scope.Declare_Constant (N, Value, Ty, 0)
                end
                Decl := Record_Declaration (Current, N, "constant")
                Current_Frame_Scope.Add_Declaration (Decl)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-enumerated_type.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-enumerated_type.aqua
@@ -1,0 +1,58 @@
+class
+   Pascal.Checks.Enumerated_Type
+
+inherit
+   Pascal.Checks.Node
+
+--  enumerated_type ::= '(' identifier_list ')'
+--
+--  Allocates a fresh Pascal.Checks.Structure (issue #139, reusing #124's
+--  record/array model: Kind discriminates, and an enum's only used feature is
+--  Size, repurposed as its number of values) and binds each name in the
+--  CURRENT scope to its ordinal position -- 0 for the first identifier, rising
+--  by one -- the same scope an ordinary constant_definition binds into, since
+--  that is where Pascal makes an enumerator's name visible: 'type colour =
+--  (red, green, blue);' makes red, green and blue usable directly, not through
+--  colour.
+--
+--  No build-stack push/pop like Record_Type / Array_Type: the identifiers are
+--  flat, nothing nested can be built while this runs, so New_Enum and every
+--  Declare_Constant happen right here in one pass over identifier_list.
+
+feature
+
+   Ty : Integer
+
+   Structure_Index : Integer
+
+   After_Identifier_List (Child : Pascal.Checks.Identifier_List)
+      local
+         It    : Aqua.Containers.Linked_List_Iterator [String]
+         Name  : String
+         Value : Integer
+         T     : Pascal.Checks.Types
+         Enum  : Pascal.Checks.Structure
+      do
+         Structure_Index := Current_Frame_Scope.New_Enum
+         from
+            It := Child.Names.New_Cursor
+            Value := 0
+         until
+            It.After
+         loop
+            Name := It.Element
+            if Current_Frame_Scope.Is_Declared_Here (Name) then
+               Error ("duplicate declaration: " & Name)
+            else
+               Current_Frame_Scope.Declare_Constant
+                  (Name, Value, T.Enumerated_Type, Structure_Index)
+            end
+            Value := Value + 1
+            It.Next
+         end
+         Enum := Current_Frame_Scope.Structure (Structure_Index)
+         Enum.Set_Size (Value)
+         Ty := T.Enumerated_Type
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-new_ordinal_type.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-new_ordinal_type.aqua
@@ -1,0 +1,33 @@
+class
+   Pascal.Checks.New_Ordinal_Type
+
+inherit
+   Pascal.Checks.Node
+
+--  new_ordinal_type ::= enumerated_type | subrange_type
+--
+--  Relays an enumerated type up to Pascal.Checks.New_Type (issue #139), which
+--  is what makes 'type colour = (red, green, blue);' bind colour itself as a
+--  type, alongside red/green/blue's own values (bound by
+--  Pascal.Checks.Enumerated_Type as it builds the type).
+--
+--  subrange_type as a STANDALONE type ('type age = 0 .. 150;') fires no hook
+--  here and leaves Ty at No_Type, which Type_Denoter then reports as Unknown --
+--  the same "not modelled" gap New_Type's own comment already notes for
+--  new_pointer_type, left for its own issue rather than folded into this one.
+--  A subrange used as an INDEX type is unaffected: that path is
+--  Pascal.Checks.Ordinal_Type, reached through index_type, not through here.
+
+feature
+
+   Ty : Integer
+
+   Structure_Index : Integer
+
+   After_Enumerated_Type (Child : Pascal.Checks.Enumerated_Type)
+      do
+         Ty := Child.Ty
+         Structure_Index := Child.Structure_Index
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-new_type.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-new_type.aqua
@@ -6,11 +6,12 @@ inherit
 
 --  new_type ::= new_ordinal_type | new_structured_type | new_pointer_type
 --
---  Relays a record or an array up to Pascal.Checks.Type_Denoter (issue #124).
---  new_ordinal_type (an enumerated or subrange type used as a whole type) and
---  new_pointer_type fire no hook here and leave Ty at No_Type, which
---  Type_Denoter then reports as Unknown -- neither is modelled, same as before
---  this issue.
+--  Relays a record or an array up to Pascal.Checks.Type_Denoter (issue #124),
+--  and an enumerated type the same way (issue #139, via
+--  Pascal.Checks.New_Ordinal_Type). A standalone subrange type ('type age =
+--  0 .. 150;') and new_pointer_type fire no hook here and leave Ty at No_Type,
+--  which Type_Denoter then reports as Unknown -- neither is modelled, same as
+--  before this issue.
 
 feature
 
@@ -19,6 +20,12 @@ feature
    Structure_Index : Integer
 
    After_New_Structured_Type (Child : Pascal.Checks.New_Structured_Type)
+      do
+         Ty := Child.Ty
+         Structure_Index := Child.Structure_Index
+      end
+
+   After_New_Ordinal_Type (Child : Pascal.Checks.New_Ordinal_Type)
       do
          Ty := Child.Ty
          Structure_Index := Child.Structure_Index

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-ordinal_type.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-ordinal_type.aqua
@@ -7,10 +7,12 @@ inherit
 --  ordinal_type ::= type_identifier | subrange_type
 --
 --  Publishes what an index_type or a base_type needs to know about its
---  ordinal (issue #124): its type, and, for a subrange, its bounds.
---  type_identifier alone (an enumerated type used as an index, e.g.
---  'array [colour] of ...') leaves Is_Known False: enumerated types are not
---  modelled, but the dimension still counts, which is what Is_Known
+--  ordinal (issue #124): its type, and its bounds, for a subrange or (issue
+--  #139) an enumerated type_identifier -- 'array [colour] of ...' now counts
+--  colour's declared values, giving Low 0 and High one less than how many
+--  there are, same as the language's own ordinal numbering. A type_identifier
+--  that names neither -- an integer/boolean/char alias, or an unmodelled type --
+--  leaves Is_Known False: the dimension still counts, which is what Is_Known
 --  distinguishes on Pascal.Checks.Bounds.
 
 feature
@@ -24,8 +26,17 @@ feature
    High : Integer
 
    After_Type_Identifier (Child : Pascal.Checks.Type_Identifier)
+      local
+         T     : Pascal.Checks.Types
+         Enum  : Pascal.Checks.Structure
       do
          Ty := Child.Ty
+         if Ty = T.Enumerated_Type and then Child.Structure_Index > 0 then
+            Enum := Current_Frame_Scope.Structure (Child.Structure_Index)
+            Is_Known := True
+            Low := 0
+            High := Enum.Size - 1
+         end
       end
 
    After_Subrange_Type (Child : Pascal.Checks.Subrange_Type)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -152,13 +152,21 @@ feature  --  declaring
          end
       end
 
-   Declare_Constant (Name : String; Value : Integer; Type_Code : Integer)
+   Declare_Constant (Name            : String
+                     Value           : Integer
+                     Type_Code       : Integer
+                     Structure_Index : Integer)
       --  Bind Name in THIS scope to a value (issue #103). Nothing is allocated:
       --  a constant is not storage, so it takes no slot in either index space.
+      --  Structure_Index is 0 for an ordinary const, and which enumerated type
+      --  when Type_Code is Types.Enumerated_Type (issue #139) -- the same
+      --  (Type_Code, Structure_Index) pair every other declaring feature here
+      --  takes, so an enumerator's name is not a new kind of binding, just this
+      --  one filled in.
       local
          B : Pascal.Checks.Binding
       do
-         create B.Make_Constant (Name, Value, Type_Code)
+         create B.Make_Constant (Name, Value, Type_Code, Structure_Index)
          Bindings.Append (B)
       end
 
@@ -224,6 +232,21 @@ feature  --  structures
             Result := P.New_Array
          else
             create S.Make_Array
+            Structures.Append (S)
+            Structure_Count := Structure_Count + 1
+            Result := Structure_Count
+         end
+      end
+
+   New_Enum : Integer
+      --  As New_Record, for an enumerated type (issue #139)
+      local
+         S : Pascal.Checks.Structure
+      do
+         if attached Parent as P then
+            Result := P.New_Enum
+         else
+            create S.Make_Enum
             Structures.Append (S)
             Structure_Count := Structure_Count + 1
             Result := Structure_Count

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-structure.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-structure.aqua
@@ -3,7 +3,8 @@ class
 
 create
    Make_Record,
-   Make_Array
+   Make_Array,
+   Make_Enum
 
 --  One record type or one array type (issue #124). Held by the root
 --  Pascal.Checks.Scope and referred to everywhere else by its index there:
@@ -45,10 +46,16 @@ feature
          Kind := Array_Kind
       end
 
+   Make_Enum
+      do
+         Kind := Enum_Kind
+      end
+
 feature  --  kind
 
    Record_Kind : Integer do Result := 1 end
    Array_Kind  : Integer do Result := 2 end
+   Enum_Kind   : Integer do Result := 3 end
 
    Kind : Integer
 
@@ -60,6 +67,11 @@ feature  --  kind
    Is_Array : Boolean
       do
          Result := Kind = Array_Kind
+      end
+
+   Is_Enum : Boolean
+      do
+         Result := Kind = Enum_Kind
       end
 
 feature  --  building
@@ -87,7 +99,12 @@ feature  --  building
       --  WATER MARK of Next_Offset, not its current value, so that rewinding
       --  for a variant does not shrink the record: a record with variants is
       --  as big as its largest variant, which is what Pascal means by one.
-      --  For an array, set once the component type is known.
+      --  For an array, set once the component type is known. For an enum
+      --  (issue #139) this is repurposed as the number of declared values --
+      --  an enum occupies one word same as an integer, but Ordinal_Type needs
+      --  its VALUE COUNT to answer Low/High for 'array [colour] of ...', and
+      --  Kind already means the rest of these features go unused for it, the
+      --  same way the array-only features go unused for a record.
 
    Set_Size (Words : Integer)
       do

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-type_definition.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-type_definition.aqua
@@ -9,11 +9,12 @@ inherit
 --
 --  An alias of a built-in -- Counter = integer -- is bound as a type name in the
 --  frame scope, so that a variable declared with it is typed as what it aliases
---  (issue #88). A record or an array binds the same way, with Structure_Index
---  carrying which one (issue #124). Anything else denotes a type outside the
---  model and is bound as Unknown, which is honest: a use of it is then reported
---  rather than guessed at. Binding it either way matters, because an unbound
---  name would resolve to whatever a variable of the same name happened to be.
+--  (issue #88). A record, an array or an enumerated type binds the same way,
+--  with Structure_Index carrying which one (issues #124, #139). Anything else
+--  denotes a type outside the model and is bound as Unknown, which is honest: a
+--  use of it is then reported rather than guessed at. Binding it either way
+--  matters, because an unbound name would resolve to whatever a variable of the
+--  same name happened to be.
 
 feature
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-types.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-types.aqua
@@ -51,6 +51,20 @@ feature
       --  side is still reported. What the code buys is that a COMPONENT of it
       --  can now be resolved (issues #125, #126, #127).
 
+   Enumerated_Type : Integer do Result := 8 end
+      --  'type colour = (red, green, blue)' (issue #139). ONE code for every
+      --  enumerated type declared in the program, the same way Structured_Type
+      --  is one code for every record and array: which one is Structure_Index,
+      --  alongside Ty, on the binding a declared value or a variable of the
+      --  type gets. Unlike Structured_Type, it IS Is_Known and Is_Ordinal --
+      --  comparing and assigning whole enum VALUES is the entire point, where
+      --  it is not for a whole record -- so two DIFFERENT enumerated types
+      --  type-check as compatible with each other, since Assignable/Combine
+      --  only ever see this one shared code. Accepted as the same kind of
+      --  coarse, honest gap #124 left for records: telling two enums apart
+      --  needs Structure_Index threaded through every operator, which nothing
+      --  in this model does yet.
+
    Is_Structured (Code : Integer) : Boolean
       do
          Result := Code = Structured_Type
@@ -69,6 +83,8 @@ feature
             Result := "char"
          elsif Code = Structured_Type then
             Result := "record or array"
+         elsif Code = Enumerated_Type then
+            Result := "enumerated type"
          else
             Result := "unknown type"
          end
@@ -95,10 +111,12 @@ feature
       end
 
    Is_Known (Code : Integer) : Boolean
-      --  One of the four modelled types: worth checking, and worth reporting
-      --  about. Anything else has either not been typed or has been reported.
+      --  One of the four scalars, or an enumerated type (issue #139): worth
+      --  checking, and worth reporting about. Anything else has either not
+      --  been typed or has been reported.
       do
-         Result := Code >= Integer_Type and then Code <= Char_Type
+         Result := (Code >= Integer_Type and then Code <= Char_Type)
+            or else Code = Enumerated_Type
       end
 
    Is_Quiet (Code : Integer) : Boolean
@@ -115,10 +133,11 @@ feature
 
    Is_Ordinal (Code : Integer) : Boolean
       --  What a for-loop control variable and a case selector must be. Real is
-      --  the one modelled type that is not ordinal.
+      --  the one modelled scalar that is not ordinal; an enumerated type
+      --  (issue #139) is, same as the language.
       do
          Result := Code = Integer_Type or else Code = Boolean_Type
-            or else Code = Char_Type
+            or else Code = Char_Type or else Code = Enumerated_Type
       end
 
    Assignable (Target : Integer; Source : Integer) : Boolean

--- a/share/aquarius/tests/pascal/test_enumerated_type_errors.pas
+++ b/share/aquarius/tests/pascal/test_enumerated_type_errors.pas
@@ -1,0 +1,24 @@
+{ Enumerated types, the error cases (issue #139). Expect exactly THREE errors:
+
+     duplicate declaration: red      -- Wrong redeclares red, already Colour's
+     cannot assign enumerated type to integer
+     operator requires numeric operands, found enumerated type and
+        enumerated type            -- '+' does not apply to enum values
+
+  Check with: bin/aquarius --check test_enumerated_type_errors.pas }
+
+program Test_Enumerated_Type_Errors;
+
+type
+   Colour = (red, green, blue);
+   Wrong  = (yellow, red);          { error: red already declared }
+
+var
+   c, d : Colour;
+   i    : integer;
+
+begin
+   c := red;
+   i := c;                          { error }
+   d := c + red                     { error }
+end.

--- a/share/aquarius/tests/pascal/test_enumerated_types.pas
+++ b/share/aquarius/tests/pascal/test_enumerated_types.pas
@@ -1,0 +1,39 @@
+{ Enumerated types (issue #139): a type declaration binds the type name AND
+  each value as a constant of it, so 'colour = (red, green, blue)' makes red,
+  green and blue usable directly wherever a colour is needed.
+
+  Covers: declaring the type and variables of it, assigning and comparing
+  values, an enum used as an array index type (its declared value count
+  becomes the dimension's extent), a type alias, and an enum-typed for-loop
+  control variable (issue #139 makes it Is_Ordinal). Expect NO errors.
+
+  Check with: bin/aquarius --check test_enumerated_types.pas }
+
+program Test_Enumerated_Types;
+
+type
+   Colour  = (red, green, blue);
+   Shade   = Colour;
+   Palette = array [Colour] of integer;
+
+var
+   c, d     : Colour;
+   s        : Shade;
+   counts   : Palette;
+   matched  : boolean;
+
+begin
+   c := red;
+   d := blue;
+   s := green;
+
+   matched := c = d;
+   matched := c <> d;
+
+   counts[red] := 1;
+   counts[green] := 2;
+   counts[blue] := counts[red] + counts[green];
+
+   for c := red to blue do
+      counts[c] := 0
+end.


### PR DESCRIPTION
Extends the structural type model from #124 to enumerated types: new_ordinal_type/enumerated_type bind the type name and declare each value as a constant with its ordinal position, reusing Structure/Scope the same way records and arrays do. Enumerated_Type is Is_Known and Is_Ordinal (unlike Structured_Type), so assignment, comparison, array indexing and for-loop control variables all work. An enum used as an array index type now gets real Low/High bounds instead of "not known".

Known accepted limitation: two different enum types type-check as compatible with each other, since Assignable/Combine only compare the shared type code, not Structure_Index -- same coarse gap #124 left for records.