### PR TITLE
Pascal.Checks: add missing standard functions (#83)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-binding.aqua
@@ -2,7 +2,8 @@ class
    Pascal.Checks.Binding
 
 create
-   Make_Local, Make_Argument, Make_Constant, Make_Routine, Make_Type, Make_With
+   Make_Local, Make_Argument, Make_Constant, Make_Routine, Make_Type, Make_With,
+   Make_Standard_Function
 
 --  One name bound to one slot of the enclosing routine's frame, held by
 --  Pascal.Checks.Scope (issue #81).
@@ -48,6 +49,15 @@ create
 --  is no storage for a with binding to call its own until the record
 --  variable's base address is), but recorded now so lowering it later is
 --  narrowing the representation, not rebuilding it.
+--
+--  A standard function is the seventh kind (issue #83): abs, ord, sqrt and
+--  the rest of the Pascal-required built-ins. It IS a routine (Is_Routine, so
+--  it resolves as a call exactly like a user-declared one) but has no
+--  Signature: several of them (abs, sqr, pred, succ) return whatever type
+--  they were given rather than one fixed result type a Signature could name,
+--  so Pascal.Checks.Variable_Access.Check_Call asks
+--  Pascal.Checks.Standard_Functions instead, from the single argument's own
+--  type.
 
 feature
 
@@ -117,6 +127,13 @@ feature
          Is_With := True
       end
 
+   Make_Standard_Function (Bound_Name : String)
+      do
+         Name := Bound_Name.To_Lower
+         Is_Routine := True
+         Is_Standard := True
+      end
+
    Name : String
 
    Offset : Integer
@@ -150,6 +167,9 @@ feature
    Is_Type : Boolean
 
    Is_With : Boolean
+
+   Is_Standard : Boolean
+      --  A standard function (issue #83); meaningful only when Is_Routine
 
    By_Reference : Boolean
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -240,6 +240,23 @@ feature
             Declare_Builtin ("writeln",  "builtin-procedure")
             Declare_Builtin ("read",     "builtin-procedure")
             Declare_Builtin ("readln",   "builtin-procedure")
+            Declare_Builtin ("abs",      "builtin-function")
+            Declare_Builtin ("arctan",   "builtin-function")
+            Declare_Builtin ("cos",      "builtin-function")
+            Declare_Builtin ("exp",      "builtin-function")
+            Declare_Builtin ("ln",       "builtin-function")
+            Declare_Builtin ("sin",      "builtin-function")
+            Declare_Builtin ("sqr",      "builtin-function")
+            Declare_Builtin ("sqrt",     "builtin-function")
+            Declare_Builtin ("round",    "builtin-function")
+            Declare_Builtin ("trunc",    "builtin-function")
+            Declare_Builtin ("chr",      "builtin-function")
+            Declare_Builtin ("ord",      "builtin-function")
+            Declare_Builtin ("pred",     "builtin-function")
+            Declare_Builtin ("succ",     "builtin-function")
+            Declare_Builtin ("odd",      "builtin-function")
+            Declare_Builtin ("eof",      "builtin-function")
+            Declare_Builtin ("eoln",     "builtin-function")
          end
       end
 
@@ -259,6 +276,38 @@ feature
          Ignore := Declare_Routine ("writeln", False, True)
          Ignore := Declare_Routine ("read", False, True)
          Ignore := Declare_Routine ("readln", False, True)
+      end
+
+   Declare_Builtin_Standard_Functions
+      --  Bind the standard functions (issue #83) in the ROOT frame scope, so
+      --  a call to one resolves like a call to any other (issue #105) -- but
+      --  as a standard-function binding rather than through Declare_Routine:
+      --  none of these has a fixed Signature, since several (abs, sqr, pred,
+      --  succ) return whatever type they were given rather than one type a
+      --  Signature could name. Pascal.Checks.Variable_Access.Check_Call reads
+      --  Pascal.Checks.Standard_Functions instead.
+      --
+      --  Re-declared for each program rather than once, same reason as
+      --  Declare_Builtin_Routines: the root scope is a once value that
+      --  Program.Before_Node resets.
+      do
+         Current_Frame_Scope.Declare_Standard_Function ("abs")
+         Current_Frame_Scope.Declare_Standard_Function ("arctan")
+         Current_Frame_Scope.Declare_Standard_Function ("cos")
+         Current_Frame_Scope.Declare_Standard_Function ("exp")
+         Current_Frame_Scope.Declare_Standard_Function ("ln")
+         Current_Frame_Scope.Declare_Standard_Function ("sin")
+         Current_Frame_Scope.Declare_Standard_Function ("sqr")
+         Current_Frame_Scope.Declare_Standard_Function ("sqrt")
+         Current_Frame_Scope.Declare_Standard_Function ("round")
+         Current_Frame_Scope.Declare_Standard_Function ("trunc")
+         Current_Frame_Scope.Declare_Standard_Function ("chr")
+         Current_Frame_Scope.Declare_Standard_Function ("ord")
+         Current_Frame_Scope.Declare_Standard_Function ("pred")
+         Current_Frame_Scope.Declare_Standard_Function ("succ")
+         Current_Frame_Scope.Declare_Standard_Function ("odd")
+         Current_Frame_Scope.Declare_Standard_Function ("eof")
+         Current_Frame_Scope.Declare_Standard_Function ("eoln")
       end
 
    Declare_Builtin (Name : String; Category : String)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
@@ -28,6 +28,7 @@ feature
          Context.Set_Active_Structure_Index (0)
          Declare_Builtin_Types
          Declare_Builtin_Routines
+         Declare_Builtin_Standard_Functions
          create Program_Scope.Make
          Enter_Scope (Program_Scope)
       end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -203,6 +203,19 @@ feature  --  declaring
          Declarations.Append (Declaration)
       end
 
+   Declare_Standard_Function (Name : String)
+      --  Bind Name in THIS scope as a standard function (issue #83): a
+      --  callable with no Signature, unlike a declared routine or
+      --  write/writeln/read/readln -- Pascal.Checks.Standard_Functions checks
+      --  its argument and computes its result type directly, since several of
+      --  these (abs, sqr, pred, succ) return whatever type they were given.
+      local
+         B : Pascal.Checks.Binding
+      do
+         create B.Make_Standard_Function (Name)
+         Bindings.Append (B)
+      end
+
 feature  --  structures
 
    New_Record : Integer

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-standard_functions.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-standard_functions.aqua
@@ -1,0 +1,142 @@
+expanded class
+   Pascal.Checks.Standard_Functions
+
+--  The required Pascal standard functions (issue #83): abs, arctan, cos, exp,
+--  ln, sin, sqr, sqrt, round, trunc, chr, ord, pred, succ, odd, eof, eoln.
+--  Every one of them takes exactly one argument, but unlike a declared
+--  routine's, several results depend on the argument's OWN type rather than
+--  one fixed type a Pascal.Checks.Signature could name -- abs, sqr, pred and
+--  succ return whatever type they were given -- so this is a small pure fold
+--  over (Name, Argument_Type), the same shape and for the same reason as
+--  Pascal.Checks.Types.Combine / Combine_Message: the rule lives here, and
+--  Pascal.Checks.Variable_Access.Check_Standard_Call reports the message.
+--
+--  eof and eoln take a file, which this system does not model (Types.
+--  Declare_Builtin_Types deliberately leaves 'text' unbound, so a file
+--  variable's type is Unknown), so their argument is accepted whatever its
+--  type: there is nothing known to check it against.
+
+feature
+
+   Is_Standard (Name : String) : Boolean
+      --  Whether Name is one of the standard functions, so
+      --  Pascal.Checks.Node.Declare_Builtin_Standard_Functions and
+      --  Variable_Access both recognise the same set.
+      local
+         N : String
+      do
+         N := Name.To_Lower
+         Result :=
+            N.Equal ("abs") or else N.Equal ("arctan")
+            or else N.Equal ("cos") or else N.Equal ("exp")
+            or else N.Equal ("ln") or else N.Equal ("sin")
+            or else N.Equal ("sqr") or else N.Equal ("sqrt")
+            or else N.Equal ("round") or else N.Equal ("trunc")
+            or else N.Equal ("chr") or else N.Equal ("ord")
+            or else N.Equal ("pred") or else N.Equal ("succ")
+            or else N.Equal ("odd") or else N.Equal ("eof")
+            or else N.Equal ("eoln")
+      end
+
+   Result_Type (Name : String; Argument_Type : Integer) : Integer
+      --  What a call to Name yields, given its one argument's type. Error
+      --  (poison) both when the argument is already poisoned -- so one
+      --  mistyped subterm does not also report the call around it -- and
+      --  when Accepts refuses it.
+      local
+         T : Pascal.Checks.Types
+      do
+         if T.Is_Quiet (Argument_Type) then
+            Result := T.Error_Type
+         elsif Accepts (Name, Argument_Type) then
+            Result := Yield (Name, Argument_Type)
+         else
+            Result := T.Error_Type
+         end
+      end
+
+   Message (Name : String; Argument_Type : Integer) : String
+      --  What to report about the argument, or the empty string if there is
+      --  nothing to say. Kept beside Result_Type so the two agree about what
+      --  is legal, same relationship as Types.Combine / Combine_Message.
+      local
+         T : Pascal.Checks.Types
+      do
+         Result := ""
+         if T.Is_Quiet (Argument_Type) then
+         elsif Accepts (Name, Argument_Type) then
+         else
+            Result := "argument of " & Name & " must be " & Requirement (Name)
+               & ", but found " & T.Name (Argument_Type)
+         end
+      end
+
+feature { None }
+
+   Accepts (Name : String; Argument_Type : Integer) : Boolean
+      --  Whether Argument_Type is legal for Name
+      local
+         N : String
+         T : Pascal.Checks.Types
+      do
+         N := Name.To_Lower
+         if N.Equal ("eof") or else N.Equal ("eoln") then
+            Result := True
+         elsif N.Equal ("chr") or else N.Equal ("odd") then
+            Result := Argument_Type = T.Integer_Type
+         elsif N.Equal ("ord") or else N.Equal ("pred") or else N.Equal ("succ")
+         then
+            Result := T.Is_Ordinal (Argument_Type)
+         else
+            --  abs, arctan, cos, exp, ln, sin, sqr, sqrt, round, trunc
+            Result := T.Is_Numeric (Argument_Type)
+         end
+      end
+
+   Yield (Name : String; Argument_Type : Integer) : Integer
+      --  What Name yields, given that Accepts already allowed Argument_Type
+      local
+         N : String
+         T : Pascal.Checks.Types
+      do
+         N := Name.To_Lower
+         if N.Equal ("abs") or else N.Equal ("sqr")
+           or else N.Equal ("pred") or else N.Equal ("succ")
+         then
+            Result := Argument_Type
+         elsif N.Equal ("arctan") or else N.Equal ("cos")
+           or else N.Equal ("exp") or else N.Equal ("ln")
+           or else N.Equal ("sin") or else N.Equal ("sqrt")
+         then
+            Result := T.Real_Type
+         elsif N.Equal ("round") or else N.Equal ("trunc") then
+            Result := T.Integer_Type
+         elsif N.Equal ("chr") then
+            Result := T.Char_Type
+         elsif N.Equal ("ord") then
+            Result := T.Integer_Type
+         elsif N.Equal ("odd") then
+            Result := T.Boolean_Type
+         else
+            --  eof, eoln
+            Result := T.Boolean_Type
+         end
+      end
+
+   Requirement (Name : String) : String
+      --  What Name's argument must be, for the error message
+      local
+         N : String
+      do
+         N := Name.To_Lower
+         if N.Equal ("chr") or else N.Equal ("odd") then
+            Result := "integer"
+         elsif N.Equal ("ord") or else N.Equal ("pred") or else N.Equal ("succ")
+         then
+            Result := "ordinal (integer, boolean, char or an enumerated type)"
+         else
+            Result := "numeric"
+         end
+      end
+
+end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -361,31 +361,68 @@ feature { None }
 
    Check_Call (Name : String; Routine_Binding : Pascal.Checks.Binding)
       --  The name is a routine. Report what a call to it cannot do, and check
-      --  the argument count and types against the signature.
+      --  the argument count and types against the signature -- or, for a
+      --  standard function (issue #83), against Pascal.Checks.Standard_
+      --  Functions instead, since it has no Signature.
       do
          Is_Call := True
-         if attached Routine_Binding.Signature as Called then
-            --  A call has the function's result type, whatever else is wrong
-            --  with it (issue #88)
-            Ty := Called.Result_Type
-         end
-         if Is_Target then
-            --  Assigning to a function name sets its result, which needs the
-            --  result slot: issue #84.
-            Error ("not supported yet: assignment to the result of " & Name)
-         elsif attached Routine_Binding.Signature as Sig then
-            if not Sig.Is_Function then
-               Error ("a procedure has no value, so it cannot be used here: "
+         if Routine_Binding.Is_Standard then
+            Check_Standard_Call (Name)
+         else
+            if attached Routine_Binding.Signature as Called then
+               --  A call has the function's result type, whatever else is
+               --  wrong with it (issue #88)
+               Ty := Called.Result_Type
+            end
+            if Is_Target then
+               --  Assigning to a function name sets its result, which needs
+               --  the result slot: issue #84.
+               Error ("not supported yet: assignment to the result of "
                       & Name)
-            elsif not Sig.Is_Variadic
-              and then Given_Arguments /= Sig.Argument_Count
-            then
-               Error ("wrong number of arguments for " & Name
-                      & ": expected " & Sig.Argument_Count.To_String
-                      & ", found " & Given_Arguments.To_String)
-            else
-               Check_Var_Arguments (Name, Sig)
-               Check_Argument_Types (Name, Sig, Argument_Types)
+            elsif attached Routine_Binding.Signature as Sig then
+               if not Sig.Is_Function then
+                  Error ("a procedure has no value, so it cannot be used"
+                         & " here: " & Name)
+               elsif not Sig.Is_Variadic
+                 and then Given_Arguments /= Sig.Argument_Count
+               then
+                  Error ("wrong number of arguments for " & Name
+                         & ": expected " & Sig.Argument_Count.To_String
+                         & ", found " & Given_Arguments.To_String)
+               else
+                  Check_Var_Arguments (Name, Sig)
+                  Check_Argument_Types (Name, Sig, Argument_Types)
+               end
+            end
+         end
+      end
+
+   Check_Standard_Call (Name : String)
+      --  A standard function (issue #83): always exactly one argument, and
+      --  its result can depend on that argument's own type in a way no fixed
+      --  Signature could name (abs, sqr, pred, succ each return whatever type
+      --  they were given). Argument_Types was filled in by the
+      --  function_designator suffix exactly as for a user routine.
+      local
+         SF   : Pascal.Checks.Standard_Functions
+         T    : Pascal.Checks.Types
+         Cur  : Aqua.Containers.Linked_List_Iterator [Integer]
+         Arg  : Integer
+         Msg  : String
+      do
+         if Is_Target then
+            Error ("not supported yet: assignment to the result of " & Name)
+         elsif Given_Arguments /= 1 then
+            Ty := T.Error_Type
+            Error ("wrong number of arguments for " & Name
+                   & ": expected 1, found " & Given_Arguments.To_String)
+         else
+            Cur := Argument_Types.New_Cursor
+            Arg := Cur.Element
+            Ty := SF.Result_Type (Name, Arg)
+            Msg := SF.Message (Name, Arg)
+            if Msg.Length > 0 then
+               Error (Msg)
             end
          end
       end

--- a/share/aquarius/tests/pascal/test_standard_function_errors.pas
+++ b/share/aquarius/tests/pascal/test_standard_function_errors.pas
@@ -1,0 +1,38 @@
+{ The standard functions, the error cases (issue #83). Expect exactly EIGHT
+  errors:
+
+     argument of abs must be numeric, but found boolean
+     argument of ord must be ordinal (integer, boolean, char or an enumerated
+       type), but found real
+     argument of chr must be integer, but found real
+     argument of odd must be integer, but found real
+     cannot assign real to integer          -- sqrt always yields a real,
+       even from a real argument; narrowing needs round/trunc
+     wrong number of arguments for sqrt: expected 1, found 0
+     wrong number of arguments for sqrt: expected 1, found 2
+     not supported yet: assignment to the result of abs
+
+  One message per mistake: an operand whose problem has been reported
+  becomes compatible with everything, so the assignment around it says
+  nothing further.
+
+  Check with: bin/aquarius --check test_standard_function_errors.pas }
+
+program Test_Standard_Function_Errors;
+
+var
+   i, j : integer;
+   r    : real;
+   c    : char;
+   flag : boolean;
+
+begin
+   i := abs(flag);         { error }
+   i := ord(r);             { error }
+   c := chr(r);              { error }
+   flag := odd(r);           { error }
+   i := sqrt(r);             { error }
+   j := sqrt;                { error }
+   j := sqrt(r, r);          { error }
+   abs(i) := 5               { error }
+end.

--- a/share/aquarius/tests/pascal/test_standard_functions.pas
+++ b/share/aquarius/tests/pascal/test_standard_functions.pas
@@ -1,0 +1,63 @@
+{ The required standard functions (issue #83): abs, arctan, cos, exp, ln,
+  sin, sqr, sqrt, round, trunc, chr, ord, pred, succ, odd, eof and eoln. Each
+  resolves as a call like any other (issue #105), but none has a fixed
+  Signature: abs, sqr, pred and succ return whatever type they were given,
+  rather than one type a Signature could name.
+
+  Covers: abs and sqr on both an integer and a real, the functions that
+  always yield a real (and accept an integer too, since it widens), round
+  and trunc narrowing a real to an integer, chr and ord converting between
+  integer and char, ord on a boolean and an enumerated type, pred and succ
+  preserving an ordinal's own type -- integer, char and an enumerated type --
+  odd, and eof/eoln on a file, whose type this system does not model.
+  Expect NO errors.
+
+  Check with: bin/aquarius --check test_standard_functions.pas }
+
+program Test_Standard_Functions;
+
+type
+   Colour = (red, green, blue);
+
+var
+   i, j : integer;
+   r, s : real;
+   c    : char;
+   flag : boolean;
+   col  : Colour;
+   f    : text;
+
+begin
+   i := abs(-3);
+   r := abs(-3.5);
+   i := sqr(4);
+   s := sqr(2.5);
+
+   r := arctan(r);
+   r := cos(r);
+   r := exp(r);
+   r := ln(r);
+   r := sin(r);
+   r := sqrt(r);
+   r := sqrt(i);         { an integer widens to real }
+
+   j := round(r);
+   j := trunc(r);
+
+   c := chr(65);
+   i := ord(c);
+   i := ord(flag);
+   i := ord(col);
+
+   c := succ(c);
+   c := pred(c);
+   j := succ(i);
+   j := pred(i);
+   col := succ(red);
+   col := pred(blue);
+
+   flag := odd(j);
+
+   flag := eof(f);
+   flag := eoln(f)
+end.


### PR DESCRIPTION
abs, arctan, cos, exp, ln, sin, sqr, sqrt, round, trunc, chr, ord, pred, succ, odd, eof and eoln are now fully type-checked calls. Several of them (abs, sqr, pred, succ) return whatever type they were given rather than one fixed type a Pascal.Checks.Signature could name, so they are a new kind of routine binding (Is_Standard) checked by the new Pascal.Checks.Standard_ Functions instead of going through a Signature.