### PR TITLE
Pascal.Checks: function name in scope in function body (#84)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-function_heading.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-function_heading.aqua
@@ -31,7 +31,7 @@ feature
          Sig := Declare_Routine (Name, True, False)
          create Func_Scope.Make
          Enter_Scope (Func_Scope)
-         Current_Frame_Scope.Set_Routine (Sig)
+         Current_Frame_Scope.Set_Routine (Name, Sig)
       end
 
    After_Result_Type (Child : Pascal.Checks.Result_Type)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_heading.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-procedure_heading.aqua
@@ -28,7 +28,7 @@ feature
          Sig := Declare_Routine (Name, False, False)
          create Proc_Scope.Make
          Enter_Scope (Proc_Scope)
-         Current_Frame_Scope.Set_Routine (Sig)
+         Current_Frame_Scope.Set_Routine (Name, Sig)
       end
 
 end

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-scope.aqua
@@ -58,9 +58,16 @@ feature
       --  reducing into the scope can be added to it (issue #105). Void for the
       --  root and the program scope, which are not routines.
 
-   Set_Routine (Signature : Pascal.Checks.Signature)
+   Routine_Name : detachable String
+      --  Lower-cased name of Routine (issue #84): what a bare reference to it,
+      --  from inside its own body, is recognised against -- the function's own
+      --  name, used without a call suffix, is the result variable rather than
+      --  a call. Void exactly when Routine is.
+
+   Set_Routine (Name : String; Signature : Pascal.Checks.Signature)
       do
          Routine := Signature
+         Routine_Name := Name.To_Lower
       end
 
    Reset
@@ -541,6 +548,29 @@ feature  --  resolving
             Result := B
          elsif attached Parent as P then
             Result := P.Lookup (Name)
+         end
+      end
+
+   Encloses_Routine (Name : String) : Boolean
+      --  Whether Name is the routine this scope's body is inside, at any
+      --  nesting depth: this scope's own Routine_Name, or an enclosing one's,
+      --  so a nested procedure can still reach an outer function's own name
+      --  (issue #84). Name is compared case-insensitively, same as any other
+      --  Pascal identifier.
+      local
+         Key : String
+         Own : Boolean
+      do
+         Key := Name.To_Lower
+         if attached Routine_Name as R then
+            if R.Equal (Key) then
+               Own := True
+            end
+         end
+         if Own then
+            Result := True
+         elsif attached Parent as P then
+            Result := P.Encloses_Routine (Key)
          end
       end
 

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-variable_access.aqua
@@ -363,35 +363,53 @@ feature { None }
       --  The name is a routine. Report what a call to it cannot do, and check
       --  the argument count and types against the signature -- or, for a
       --  standard function (issue #83), against Pascal.Checks.Standard_
-      --  Functions instead, since it has no Signature.
+      --  Functions instead, since it has no Signature -- UNLESS Name, used
+      --  bare with no call syntax at all, is the enclosing function's own
+      --  name: then it is the result variable (issue #84), not a call, and
+      --  neither Is_Call nor an error is set at all.
+      local
+         Own_Result : Boolean
       do
-         Is_Call := True
-         if Routine_Binding.Is_Standard then
-            Check_Standard_Call (Name)
-         else
-            if attached Routine_Binding.Signature as Called then
-               --  A call has the function's result type, whatever else is
-               --  wrong with it (issue #88)
-               Ty := Called.Result_Type
+         if not Has_Argument_List then
+            if attached Routine_Binding.Signature as Sig then
+               if Sig.Is_Function then
+                  if Current_Frame_Scope.Encloses_Routine (Name) then
+                     Own_Result := True
+                  end
+               end
             end
-            if Is_Target then
-               --  Assigning to a function name sets its result, which needs
-               --  the result slot: issue #84.
-               Error ("not supported yet: assignment to the result of "
-                      & Name)
-            elsif attached Routine_Binding.Signature as Sig then
-               if not Sig.Is_Function then
-                  Error ("a procedure has no value, so it cannot be used"
-                         & " here: " & Name)
-               elsif not Sig.Is_Variadic
-                 and then Given_Arguments /= Sig.Argument_Count
-               then
-                  Error ("wrong number of arguments for " & Name
-                         & ": expected " & Sig.Argument_Count.To_String
-                         & ", found " & Given_Arguments.To_String)
-               else
-                  Check_Var_Arguments (Name, Sig)
-                  Check_Argument_Types (Name, Sig, Argument_Types)
+         end
+         if Own_Result then
+            if attached Routine_Binding.Signature as Sig then
+               Ty := Sig.Result_Type
+            end
+         else
+            Is_Call := True
+            if Routine_Binding.Is_Standard then
+               Check_Standard_Call (Name)
+            else
+               if attached Routine_Binding.Signature as Called then
+                  --  A call has the function's result type, whatever else is
+                  --  wrong with it (issue #88)
+                  Ty := Called.Result_Type
+               end
+               if Is_Target then
+                  Error ("not supported yet: assignment to the result of "
+                         & Name)
+               elsif attached Routine_Binding.Signature as Sig then
+                  if not Sig.Is_Function then
+                     Error ("a procedure has no value, so it cannot be used"
+                            & " here: " & Name)
+                  elsif not Sig.Is_Variadic
+                    and then Given_Arguments /= Sig.Argument_Count
+                  then
+                     Error ("wrong number of arguments for " & Name
+                            & ": expected " & Sig.Argument_Count.To_String
+                            & ", found " & Given_Arguments.To_String)
+                  else
+                     Check_Var_Arguments (Name, Sig)
+                     Check_Argument_Types (Name, Sig, Argument_Types)
+                  end
                end
             end
          end

--- a/share/aquarius/tests/pascal/test_function_result.pas
+++ b/share/aquarius/tests/pascal/test_function_result.pas
@@ -1,0 +1,48 @@
+{ A function's own name is in scope inside its own body (issue #84): unlike
+  anywhere else, it does not mean a call there -- assigning to it sets the
+  result, and it may be read back before the function returns.
+
+  Covers: a simple result assignment, reading the result back (Clamp), a
+  recursive call written the ordinary way -- with parentheses -- alongside a
+  bare assignment to the same name in the same function (Factorial), and a
+  boolean result. Expect NO errors.
+
+  Check with: bin/aquarius --check test_function_result.pas }
+
+program Test_Function_Result;
+
+var
+   a, b : integer;
+   flag : boolean;
+
+function Plus_1(x : integer) : integer;
+begin
+   Plus_1 := x + 1
+end;
+
+function Clamp(x : integer) : integer;
+begin
+   Clamp := x;
+   if Clamp > 100 then Clamp := 100;
+   if Clamp < 0 then Clamp := 0
+end;
+
+function Factorial(n : integer) : integer;
+begin
+   if n <= 1 then
+      Factorial := 1
+   else
+      Factorial := n * Factorial(n - 1)   { a recursive call, written with parens }
+end;
+
+function Is_Positive(n : integer) : boolean;
+begin
+   Is_Positive := n > 0
+end;
+
+begin
+   a := Plus_1(1);
+   b := Clamp(150);
+   a := Factorial(5);
+   flag := Is_Positive(a)
+end.

--- a/share/aquarius/tests/pascal/test_function_result_errors.pas
+++ b/share/aquarius/tests/pascal/test_function_result_errors.pas
@@ -1,0 +1,40 @@
+{ The boundaries of a function's own name in scope (issue #84). Expect
+  exactly THREE errors:
+
+     cannot assign integer to boolean
+        -- Is_Even's own name is boolean, not integer
+     not supported yet: assignment to the result of Loop_Body
+        -- a PROCEDURE has no result, so its own bare name assigned to is
+           still the (unsupported) old call-target case, not a variable
+     wrong number of arguments for Plus_1: expected 1, found 0
+        -- Plus_1's own name, referenced bare from OUTSIDE its body, is an
+           ordinary call, not its result
+
+  Check with: bin/aquarius --check test_function_result_errors.pas }
+
+program Test_Function_Result_Errors;
+
+var
+   flag : boolean;
+   a    : integer;
+
+function Is_Even(n : integer) : boolean;
+begin
+   Is_Even := n              { error }
+end;
+
+procedure Loop_Body;
+begin
+   Loop_Body := 5            { error }
+end;
+
+function Plus_1(x : integer) : integer;
+begin
+   Plus_1 := x + 1
+end;
+
+begin
+   flag := Is_Even(4);
+   Loop_Body;
+   a := Plus_1               { error }
+end.


### PR DESCRIPTION
A function's own name, referenced bare (no call syntax) from inside its own body at any nesting depth, is its result variable, not a call -- assigning to it sets the result, and it may be read back before the function returns. Pascal.Checks.Scope tracks a routine scope's lower-cased name alongside its Signature (Encloses_Routine walks the enclosing chain by name) so Variable_Access.Check_Call can tell this apart from an ordinary call: a procedure's own name, or any reference written with a call suffix (including genuine recursion), is unaffected.

This was previously reported as "not supported yet: assignment to the result of X" for every self-assigning function, which is most of them -- fixes a large fraction of the diagnostics in basics.pas and the other sample programs.