### PR TITLE
Pascal.Checks: declare true and false (#88)

### DIFF
--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-node.aqua
@@ -257,6 +257,8 @@ feature
             Declare_Builtin ("odd",      "builtin-function")
             Declare_Builtin ("eof",      "builtin-function")
             Declare_Builtin ("eoln",     "builtin-function")
+            Declare_Builtin ("false",    "builtin-constant")
+            Declare_Builtin ("true",     "builtin-constant")
          end
       end
 
@@ -308,6 +310,24 @@ feature
          Current_Frame_Scope.Declare_Standard_Function ("odd")
          Current_Frame_Scope.Declare_Standard_Function ("eof")
          Current_Frame_Scope.Declare_Standard_Function ("eoln")
+      end
+
+   Declare_Builtin_Constants
+      --  Bind false and true (issue #88, reopened) as ordinary Boolean_Type
+      --  constants in the ROOT frame scope, the same way #103 binds a user
+      --  const and #139 binds an enum value -- Boolean is already its own
+      --  scalar type code with every rule (comparison, 'and'/'or'/'not', the
+      --  ordinal rules that give 'for' loops and ord/succ/pred) in place, so
+      --  nothing else needs to change for these to just work.
+      --
+      --  Re-declared for each program rather than once, same reason as
+      --  Declare_Builtin_Routines: the root scope is a once value that
+      --  Program.Before_Node resets.
+      local
+         T : Pascal.Checks.Types
+      do
+         Current_Frame_Scope.Declare_Constant ("false", 0, T.Boolean_Type, 0)
+         Current_Frame_Scope.Declare_Constant ("true", 1, T.Boolean_Type, 0)
       end
 
    Declare_Builtin (Name : String; Category : String)

--- a/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
+++ b/share/aquarius/grammar/pascal/aqua/pascal-checks-program.aqua
@@ -29,6 +29,7 @@ feature
          Declare_Builtin_Types
          Declare_Builtin_Routines
          Declare_Builtin_Standard_Functions
+         Declare_Builtin_Constants
          create Program_Scope.Make
          Enter_Scope (Program_Scope)
       end

--- a/share/aquarius/tests/pascal/test_types.pas
+++ b/share/aquarius/tests/pascal/test_types.pas
@@ -3,11 +3,8 @@
 
   Covers: a declared type on every variable, an alias of a built-in, the two
   divisions, mixed arithmetic, integer-to-real promotion, comparisons, boolean
-  operators, an ordinal control variable, and a call checked against a typed
-  parameter list.
-
-  Note there is no 'true' or 'false': the standard boolean constants are not
-  declared yet (issue #83), so the booleans here come from comparisons.
+  operators (including the true/false constants, issue #88), an ordinal
+  control variable, and a call checked against a typed parameter list.
 
   Check with: bin/aquarius --check test_types.pas }
 
@@ -56,6 +53,9 @@ begin
    flag := flag and (i = j);
    flag := not flag;
    flag := (i > 0) or (j > 0);
+   flag := true;
+   flag := false;
+   flag := true and not false;
 
    for i := 1 to Limit do
       j := j + i;


### PR DESCRIPTION
true and false are pre-declared Boolean_Type constants (value 1/0) in the root frame scope, the same Declare_Constant path #103 and #139 already use for a user const and an enum value. Boolean stays its own scalar type code rather than becoming an enumeration: it is already Is_Ordinal/Is_Known, so ord/succ/pred/for-loops already work on it, and unifying it with the general enum model would dilute the accepted "two different enums compare compatible" imprecision onto real booleans.